### PR TITLE
feat: Config dialog + Endpoint Management dialog (closes #8, #9, #35)

### DIFF
--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -5796,13 +5796,17 @@ namespace EndpointChecker
 
         public void mainMenu_EndpointsList_Click(object sender, EventArgs e)
         {
-            if (File.Exists(endpointDefinitionsFile))
+            using (EndpointManagementDialog dlg = new EndpointManagementDialog(this))
             {
-                BrowseEndpoint(
-                endpointDefinitionsFile,
-                null,
-                null,
-                null);
+                dlg.ShowDialog(this);
+                if (dlg.FileWasModified)
+                {
+                    SetControls(false, true);
+                    lbl_EndpointsListLoading.Visible = true;
+                    lbl_ProgressCount.Visible = true;
+                    lv_Endpoints.Visible = false;
+                    LoadEndpointReferences();
+                }
             }
         }
 
@@ -5832,13 +5836,9 @@ namespace EndpointChecker
 
         public void mainMenu_ConfigFile_Click(object sender, EventArgs e)
         {
-            if (File.Exists(appConfigFile))
+            using (ConfigDialog dlg = new ConfigDialog(this))
             {
-                BrowseEndpoint(
-                appConfigFile,
-                null,
-                null,
-                null);
+                dlg.ShowDialog(this);
             }
         }
 
@@ -5947,13 +5947,87 @@ namespace EndpointChecker
             }
         }
 
-        private static IEnumerable<Control> DescendantControls(Control parent)
+        public static IEnumerable<Control> DescendantControls(Control parent)
         {
             foreach (Control c in parent.Controls)
             {
                 yield return c;
                 foreach (Control child in DescendantControls(c))
                     yield return child;
+            }
+        }
+
+        public static void ApplyDarkTheme(Control root)
+        {
+            Color bg       = Color.FromArgb( 22,  25,  44);
+            Color surface  = Color.FromArgb( 30,  34,  58);
+            Color input    = Color.FromArgb( 38,  43,  75);
+            Color accent   = Color.FromArgb( 88, 121, 224);
+            Color textMain = Color.FromArgb(200, 212, 240);
+
+            root.BackColor = bg;
+
+            foreach (Control ctrl in DescendantControls(root))
+            {
+                switch (ctrl)
+                {
+                    case TabPage tp:
+                        tp.BackColor = surface;
+                        break;
+                    case Panel p:
+                        p.BackColor = bg;
+                        break;
+                    case TabControl tc:
+                        tc.BackColor = surface;
+                        break;
+                    case GroupBox gb:
+                        gb.BackColor = surface;
+                        gb.ForeColor = accent;
+                        break;
+                    case Label lbl:
+                        lbl.ForeColor = textMain;
+                        break;
+                    case CheckBox cb:
+                        cb.UseVisualStyleBackColor = false;
+                        cb.BackColor = surface;
+                        cb.ForeColor = textMain;
+                        break;
+                    case TextBox tb:
+                        tb.BackColor = input;
+                        tb.ForeColor = textMain;
+                        tb.BorderStyle = BorderStyle.FixedSingle;
+                        break;
+                    case NumericUpDown nud:
+                        nud.BackColor = input;
+                        nud.ForeColor = textMain;
+                        break;
+                    case ComboBox cbo:
+                        cbo.BackColor = input;
+                        cbo.ForeColor = textMain;
+                        break;
+                    case ListView lv:
+                        lv.BackColor = surface;
+                        lv.ForeColor = textMain;
+                        break;
+                    case DataGridView dgv:
+                        dgv.BackgroundColor = surface;
+                        dgv.ForeColor = textMain;
+                        dgv.GridColor = accent;
+                        dgv.DefaultCellStyle.BackColor = input;
+                        dgv.DefaultCellStyle.ForeColor = textMain;
+                        dgv.ColumnHeadersDefaultCellStyle.BackColor = surface;
+                        dgv.ColumnHeadersDefaultCellStyle.ForeColor = accent;
+                        dgv.ColumnHeadersDefaultCellStyle.SelectionBackColor = Color.FromArgb(55, 75, 145);
+                        dgv.AlternatingRowsDefaultCellStyle.BackColor = Color.FromArgb(32, 37, 62);
+                        dgv.AlternatingRowsDefaultCellStyle.ForeColor = textMain;
+                        break;
+                    case Button btn when btn.Image == null && btn.BackgroundImage == null:
+                        btn.FlatStyle = FlatStyle.Flat;
+                        btn.BackColor = input;
+                        btn.ForeColor = textMain;
+                        btn.FlatAppearance.BorderColor = accent;
+                        break;
+                }
             }
         }
 

--- a/src/ConfigDialog.cs
+++ b/src/ConfigDialog.cs
@@ -1,0 +1,366 @@
+using EndpointChecker.Properties;
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace EndpointChecker
+{
+    public class ConfigDialog : Form
+    {
+        private readonly CheckerMainForm _owner;
+
+        // Tab 1 — Refresh & Notifications
+        private CheckBox cb_AutoRefresh;
+        private CheckBox cb_ContinuousRefresh;
+        private CheckBox cb_AutoAdjustInterval;
+        private CheckBox cb_ScanOnStartup;
+        private CheckBox cb_TrayNotify;
+        private NumericUpDown num_RefreshInterval;
+
+        // Tab 2 — Scan
+        private ComboBox cmb_ValidationMethod;
+        private CheckBox cb_TestPing;
+        private CheckBox cb_AllowRedirect;
+        private CheckBox cb_ValidateSSL;
+        private NumericUpDown num_PingTimeout;
+        private NumericUpDown num_HttpTimeout;
+        private NumericUpDown num_FtpTimeout;
+        private NumericUpDown num_ParallelThreads;
+
+        // Tab 3 — Resolution
+        private CheckBox cb_ResolveDns;
+        private CheckBox cb_ResolveIp;
+        private CheckBox cb_ResolveMac;
+        private CheckBox cb_ResolveShares;
+        private CheckBox cb_PageMetaInfo;
+        private CheckBox cb_RemoveUrlParams;
+        private CheckBox cb_PageLinks;
+        private CheckBox cb_SaveResponse;
+
+        // Tab 4 — Export
+        private CheckBox cb_ExportXlsx;
+        private CheckBox cb_ExportJson;
+        private CheckBox cb_ExportXml;
+        private CheckBox cb_ExportHtml;
+        private TextBox txt_ExportDir;
+
+        // Tab 5 — Tools & API Keys
+        private TextBox txt_VncPath;
+        private TextBox txt_PuttyPath;
+        private TextBox txt_VirusTotal;
+        private TextBox txt_GoogleMaps;
+
+        public ConfigDialog(CheckerMainForm owner)
+        {
+            _owner = owner;
+            BuildUI();
+            LoadSettings();
+            CheckerMainForm.ApplyDarkTheme(this);
+        }
+
+        // ── UI construction ────────────────────────────────────────────────────
+
+        private void BuildUI()
+        {
+            Text            = "Configuration";
+            Size            = new Size(600, 510);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox     = false;
+            MinimizeBox     = false;
+            StartPosition   = FormStartPosition.CenterParent;
+            Font            = new Font("Segoe UI", 9f);
+
+            var tabs = new TabControl { Dock = DockStyle.Fill };
+            tabs.TabPages.Add(BuildRefreshTab());
+            tabs.TabPages.Add(BuildScanTab());
+            tabs.TabPages.Add(BuildResolutionTab());
+            tabs.TabPages.Add(BuildExportTab());
+            tabs.TabPages.Add(BuildToolsTab());
+
+            var footer = new Panel { Dock = DockStyle.Bottom, Height = 46 };
+            var btnOk     = new Button { Text = "OK",     DialogResult = DialogResult.OK,     Size = new Size(88, 28), Location = new Point(392, 9) };
+            var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Size = new Size(88, 28), Location = new Point(488, 9) };
+            btnOk.Click += BtnOk_Click;
+            footer.Controls.AddRange(new Control[] { btnOk, btnCancel });
+
+            Controls.Add(tabs);
+            Controls.Add(footer);
+            AcceptButton = btnOk;
+            CancelButton = btnCancel;
+        }
+
+        private TabPage BuildRefreshTab()
+        {
+            var tab = new TabPage("Refresh & Notifications");
+            int y = 16;
+
+            cb_AutoRefresh       = AddCheck(tab, "Enable automatic refresh",        ref y);
+            cb_ContinuousRefresh = AddCheck(tab, "Continuous refresh (loop)",       ref y);
+            cb_AutoAdjustInterval= AddCheck(tab, "Auto-adjust refresh interval",    ref y);
+            cb_ScanOnStartup     = AddCheck(tab, "Scan on startup",                 ref y);
+            cb_TrayNotify        = AddCheck(tab, "Tray balloon notification on error", ref y);
+
+            y += 10;
+            AddLabel(tab, "Refresh interval (minutes):", 14, y);
+            num_RefreshInterval = new NumericUpDown
+            {
+                Location = new Point(230, y - 2), Width = 80,
+                Minimum = 0, Maximum = 1440, DecimalPlaces = 0
+            };
+            tab.Controls.Add(num_RefreshInterval);
+
+            return tab;
+        }
+
+        private TabPage BuildScanTab()
+        {
+            var tab = new TabPage("Scan");
+            int y = 16;
+
+            AddLabel(tab, "Validation method:", 14, y);
+            cmb_ValidationMethod = new ComboBox
+            {
+                Location = new Point(190, y - 2), Width = 180,
+                DropDownStyle = ComboBoxStyle.DropDownList
+            };
+            cmb_ValidationMethod.Items.Add("Protocol");
+            cmb_ValidationMethod.Items.Add("Ping");
+            tab.Controls.Add(cmb_ValidationMethod);
+            y += 32;
+
+            cb_TestPing      = AddCheck(tab, "Test Ping (ICMP)", ref y);
+            cb_AllowRedirect = AddCheck(tab, "Allow automatic HTTP redirects", ref y);
+            cb_ValidateSSL   = AddCheck(tab, "Validate SSL certificate", ref y);
+            y += 10;
+
+            AddLabel(tab, "Ping timeout (seconds):", 14, y);
+            num_PingTimeout = new NumericUpDown { Location = new Point(230, y - 2), Width = 80, Minimum = 0, Maximum = 300 };
+            tab.Controls.Add(num_PingTimeout);
+            y += 28;
+
+            AddLabel(tab, "HTTP request timeout (sec):", 14, y);
+            num_HttpTimeout = new NumericUpDown { Location = new Point(230, y - 2), Width = 80, Minimum = 0, Maximum = 300 };
+            tab.Controls.Add(num_HttpTimeout);
+            y += 28;
+
+            AddLabel(tab, "FTP request timeout (sec):", 14, y);
+            num_FtpTimeout = new NumericUpDown { Location = new Point(230, y - 2), Width = 80, Minimum = 0, Maximum = 300 };
+            tab.Controls.Add(num_FtpTimeout);
+            y += 28;
+
+            AddLabel(tab, "Parallel scan threads:", 14, y);
+            num_ParallelThreads = new NumericUpDown { Location = new Point(230, y - 2), Width = 80, Minimum = 1, Maximum = 64 };
+            tab.Controls.Add(num_ParallelThreads);
+
+            return tab;
+        }
+
+        private TabPage BuildResolutionTab()
+        {
+            var tab = new TabPage("Resolution");
+            int y = 16;
+
+            cb_ResolveDns    = AddCheck(tab, "Resolve DNS names",             ref y);
+            cb_ResolveIp     = AddCheck(tab, "Resolve IP addresses",           ref y);
+            cb_ResolveMac    = AddCheck(tab, "Resolve MAC addresses",          ref y);
+            cb_ResolveShares = AddCheck(tab, "Resolve network shares",         ref y);
+            cb_PageMetaInfo  = AddCheck(tab, "Resolve page meta info (HTML)",  ref y);
+            cb_RemoveUrlParams = AddCheck(tab, "Remove URL parameters",        ref y);
+            cb_PageLinks     = AddCheck(tab, "Resolve page links (HTML)",      ref y);
+            cb_SaveResponse  = AddCheck(tab, "Save HTTP response to disk",     ref y);
+
+            return tab;
+        }
+
+        private TabPage BuildExportTab()
+        {
+            var tab = new TabPage("Export");
+            int y = 16;
+
+            cb_ExportXlsx = AddCheck(tab, "Export to XLSX (Excel)", ref y);
+            cb_ExportJson = AddCheck(tab, "Export to JSON",          ref y);
+            cb_ExportXml  = AddCheck(tab, "Export to XML",           ref y);
+            cb_ExportHtml = AddCheck(tab, "Export to HTML",          ref y);
+            y += 10;
+
+            AddLabel(tab, "Export directory:", 14, y);
+            txt_ExportDir = new TextBox { Location = new Point(14, y + 22), Width = 440, ReadOnly = true };
+            var btnBrowse = new Button { Text = "Browse...", Location = new Point(460, y + 20), Size = new Size(88, 24) };
+            btnBrowse.Click += (s, e) =>
+            {
+                using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+                {
+                    fbd.Description = "Select export directory";
+                    if (!string.IsNullOrEmpty(txt_ExportDir.Text) && Directory.Exists(txt_ExportDir.Text))
+                        fbd.SelectedPath = txt_ExportDir.Text;
+                    if (fbd.ShowDialog() == DialogResult.OK)
+                        txt_ExportDir.Text = fbd.SelectedPath;
+                }
+            };
+            tab.Controls.AddRange(new Control[] { txt_ExportDir, btnBrowse });
+
+            return tab;
+        }
+
+        private TabPage BuildToolsTab()
+        {
+            var tab = new TabPage("Tools & API Keys");
+            int y = 16;
+
+            AddLabel(tab, "VNC Viewer executable:", 14, y);
+            txt_VncPath = new TextBox { Location = new Point(14, y + 22), Width = 440, ReadOnly = true };
+            var btnVnc = new Button { Text = "Browse...", Location = new Point(460, y + 20), Size = new Size(88, 24) };
+            btnVnc.Click += (s, e) => BrowseExe(txt_VncPath);
+            tab.Controls.AddRange(new Control[] { txt_VncPath, btnVnc });
+            y += 58;
+
+            AddLabel(tab, "PuTTY executable:", 14, y);
+            txt_PuttyPath = new TextBox { Location = new Point(14, y + 22), Width = 440, ReadOnly = true };
+            var btnPutty = new Button { Text = "Browse...", Location = new Point(460, y + 20), Size = new Size(88, 24) };
+            btnPutty.Click += (s, e) => BrowseExe(txt_PuttyPath);
+            tab.Controls.AddRange(new Control[] { txt_PuttyPath, btnPutty });
+            y += 58;
+
+            AddLabel(tab, "VirusTotal API key:", 14, y);
+            txt_VirusTotal = new TextBox { Location = new Point(14, y + 22), Width = 534 };
+            tab.Controls.Add(txt_VirusTotal);
+            y += 58;
+
+            AddLabel(tab, "Google Maps API key:", 14, y);
+            txt_GoogleMaps = new TextBox { Location = new Point(14, y + 22), Width = 534 };
+            tab.Controls.Add(txt_GoogleMaps);
+
+            return tab;
+        }
+
+        // ── Settings I/O ───────────────────────────────────────────────────────
+
+        private void LoadSettings()
+        {
+            var s = Settings.Default;
+
+            cb_AutoRefresh.Checked        = s.Config_EnableAutomaticRefresh;
+            cb_ContinuousRefresh.Checked  = s.Config_EnableContinuousRefresh;
+            cb_AutoAdjustInterval.Checked = s.Config_AutoAdjustRefreshInterval;
+            cb_ScanOnStartup.Checked      = s.Config_ScanOnStartup;
+            cb_TrayNotify.Checked         = s.Config_EnableTrayNotificationsOnError;
+            num_RefreshInterval.Value     = Math.Max(num_RefreshInterval.Minimum,
+                                            Math.Min(num_RefreshInterval.Maximum, s.Config_AutomaticRefreshIntervalSeconds));
+
+            int vIdx = s.Config_ValidationMethod;
+            cmb_ValidationMethod.SelectedIndex = (vIdx >= 0 && vIdx < cmb_ValidationMethod.Items.Count) ? vIdx : 0;
+            cb_TestPing.Checked      = s.Config_TestPing;
+            cb_AllowRedirect.Checked = s.Config_AllowAutoRedirect;
+            cb_ValidateSSL.Checked   = s.Config_ValidateSSLCertificate;
+            num_PingTimeout.Value    = Clamp(s.Config_PingTimeoutSeconds,    num_PingTimeout.Minimum,    num_PingTimeout.Maximum);
+            num_HttpTimeout.Value    = Clamp(s.Config_HTTP_RequestTimeoutSeconds, num_HttpTimeout.Minimum, num_HttpTimeout.Maximum);
+            num_FtpTimeout.Value     = Clamp(s.Config_FTP_RequestTimeoutSeconds,  num_FtpTimeout.Minimum,  num_FtpTimeout.Maximum);
+            num_ParallelThreads.Value= Clamp(s.Config_ParallelThreadsCount,  num_ParallelThreads.Minimum, num_ParallelThreads.Maximum);
+
+            cb_ResolveDns.Checked    = s.Config_Resolve_DNS_Names;
+            cb_ResolveIp.Checked     = s.Config_Resolve_IP_Addresses;
+            cb_ResolveMac.Checked    = s.Config_Resolve_MAC_Addresses;
+            cb_ResolveShares.Checked = s.Config_ResolveNetworkShares;
+            cb_PageMetaInfo.Checked  = s.Config_ResolvePageMetaInfo;
+            cb_RemoveUrlParams.Checked = s.Config_RemoveURLParameters;
+            cb_PageLinks.Checked     = s.Config_ResolvePageLinks;
+            cb_SaveResponse.Checked  = s.Config_SaveResponse;
+
+            cb_ExportXlsx.Checked = s.Config_ExportEndpointsStatus_XLSX;
+            cb_ExportJson.Checked = s.Config_ExportEndpointsStatus_JSON;
+            cb_ExportXml.Checked  = s.Config_ExportEndpointsStatus_XML;
+            cb_ExportHtml.Checked = s.Config_ExportEndpointsStatus_HTML;
+            txt_ExportDir.Text    = s.Config_EndpointsStatusExportDirectory;
+
+            txt_VncPath.Text    = s.Config_Executable_VNCViewer;
+            txt_PuttyPath.Text  = s.Config_Executable_Putty;
+            txt_VirusTotal.Text = s.VirusTotal_API_Key;
+            txt_GoogleMaps.Text = s.GoogleMaps_API_Key;
+        }
+
+        private void BtnOk_Click(object sender, EventArgs e)
+        {
+            var s = Settings.Default;
+
+            s.Config_EnableAutomaticRefresh         = cb_AutoRefresh.Checked;
+            s.Config_EnableContinuousRefresh        = cb_ContinuousRefresh.Checked;
+            s.Config_AutoAdjustRefreshInterval      = cb_AutoAdjustInterval.Checked;
+            s.Config_ScanOnStartup                  = cb_ScanOnStartup.Checked;
+            s.Config_EnableTrayNotificationsOnError = cb_TrayNotify.Checked;
+            s.Config_AutomaticRefreshIntervalSeconds= num_RefreshInterval.Value;
+
+            s.Config_ValidationMethod         = cmb_ValidationMethod.SelectedIndex;
+            s.Config_TestPing                 = cb_TestPing.Checked;
+            s.Config_AllowAutoRedirect        = cb_AllowRedirect.Checked;
+            s.Config_ValidateSSLCertificate   = cb_ValidateSSL.Checked;
+            s.Config_PingTimeoutSeconds       = num_PingTimeout.Value;
+            s.Config_HTTP_RequestTimeoutSeconds = num_HttpTimeout.Value;
+            s.Config_FTP_RequestTimeoutSeconds  = num_FtpTimeout.Value;
+            s.Config_ParallelThreadsCount     = num_ParallelThreads.Value;
+
+            s.Config_Resolve_DNS_Names    = cb_ResolveDns.Checked;
+            s.Config_Resolve_IP_Addresses = cb_ResolveIp.Checked;
+            s.Config_Resolve_MAC_Addresses = cb_ResolveMac.Checked;
+            s.Config_ResolveNetworkShares = cb_ResolveShares.Checked;
+            s.Config_ResolvePageMetaInfo  = cb_PageMetaInfo.Checked;
+            s.Config_RemoveURLParameters  = cb_RemoveUrlParams.Checked;
+            s.Config_ResolvePageLinks     = cb_PageLinks.Checked;
+            s.Config_SaveResponse         = cb_SaveResponse.Checked;
+
+            s.Config_ExportEndpointsStatus_XLSX = cb_ExportXlsx.Checked;
+            s.Config_ExportEndpointsStatus_JSON = cb_ExportJson.Checked;
+            s.Config_ExportEndpointsStatus_XML  = cb_ExportXml.Checked;
+            s.Config_ExportEndpointsStatus_HTML = cb_ExportHtml.Checked;
+            s.Config_EndpointsStatusExportDirectory = txt_ExportDir.Text.Trim();
+
+            s.Config_Executable_VNCViewer = txt_VncPath.Text.Trim();
+            s.Config_Executable_Putty     = txt_PuttyPath.Text.Trim();
+            s.VirusTotal_API_Key          = txt_VirusTotal.Text.Trim();
+            s.GoogleMaps_API_Key          = txt_GoogleMaps.Text.Trim();
+
+            s.HasSavedConfiguration = true;
+            s.Save();
+
+            // Sync the Program-level static fields that LoadConfiguration reads from
+            Program.app_ScanOnStartup         = cb_ScanOnStartup.Checked;
+            Program.apiKey_VirusTotal         = txt_VirusTotal.Text.Trim();
+            Program.apiKey_GoogleMaps         = txt_GoogleMaps.Text.Trim();
+            CheckerMainForm.appExecutable_VNC   = txt_VncPath.Text.Trim();
+            CheckerMainForm.appExecutable_Putty = txt_PuttyPath.Text.Trim();
+            if (Directory.Exists(txt_ExportDir.Text.Trim()))
+                Program.statusExport_Directory = txt_ExportDir.Text.Trim();
+
+            _owner.LoadConfiguration();
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private static CheckBox AddCheck(Control parent, string text, ref int y)
+        {
+            var cb = new CheckBox { Text = text, Location = new Point(14, y), AutoSize = true };
+            parent.Controls.Add(cb);
+            y += 24;
+            return cb;
+        }
+
+        private static void AddLabel(Control parent, string text, int x, int y)
+        {
+            parent.Controls.Add(new Label { Text = text, Location = new Point(x, y + 2), AutoSize = true });
+        }
+
+        private static void BrowseExe(TextBox target)
+        {
+            using (OpenFileDialog ofd = new OpenFileDialog())
+            {
+                ofd.Filter = "Executable files (*.exe)|*.exe|All files (*.*)|*.*";
+                ofd.Title  = "Select executable";
+                if (ofd.ShowDialog() == DialogResult.OK)
+                    target.Text = ofd.FileName;
+            }
+        }
+
+        private static decimal Clamp(decimal value, decimal min, decimal max)
+            => value < min ? min : value > max ? max : value;
+    }
+}

--- a/src/EndpointManagementDialog.cs
+++ b/src/EndpointManagementDialog.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+
+namespace EndpointChecker
+{
+    public class EndpointManagementDialog : Form
+    {
+        private readonly CheckerMainForm _owner;
+        private readonly string _filePath;
+
+        public bool FileWasModified { get; private set; }
+
+        // File is modelled as a mixed list of comment/blank lines and endpoint lines.
+        // Only endpoint lines are shown in the grid; comments are preserved on save.
+        private sealed class FileLine
+        {
+            public bool   IsEndpoint;
+            public string Name;
+            public string Url;
+            public string Raw;   // original text for comment / blank lines
+        }
+
+        private List<FileLine> _lines;
+        private DataGridView   _grid;
+
+        public EndpointManagementDialog(CheckerMainForm owner)
+        {
+            _owner    = owner;
+            _filePath = Program.endpointDefinitionsFile;
+            BuildUI();
+            LoadFile();
+            CheckerMainForm.ApplyDarkTheme(this);
+        }
+
+        // ── UI ─────────────────────────────────────────────────────────────────
+
+        private void BuildUI()
+        {
+            Text            = "Endpoint Management";
+            Size            = new Size(720, 540);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox     = false;
+            MinimizeBox     = false;
+            StartPosition   = FormStartPosition.CenterParent;
+            Font            = new Font("Segoe UI", 9f);
+
+            _grid = new DataGridView
+            {
+                Location              = new Point(8, 8),
+                Size                  = new Size(688, 420),
+                AllowUserToAddRows    = false,
+                AllowUserToDeleteRows = false,
+                RowHeadersVisible     = false,
+                SelectionMode         = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect           = false,
+                AutoSizeColumnsMode   = DataGridViewAutoSizeColumnsMode.None,
+                EditMode              = DataGridViewEditMode.EditOnEnter,
+                ClipboardCopyMode     = DataGridViewClipboardCopyMode.EnableWithoutHeaderText,
+            };
+
+            var colName = new DataGridViewTextBoxColumn
+            {
+                HeaderText = "Name",
+                Name       = "colName",
+                Width      = 180,
+                SortMode   = DataGridViewColumnSortMode.NotSortable,
+            };
+            var colUrl = new DataGridViewTextBoxColumn
+            {
+                HeaderText = "URL",
+                Name       = "colUrl",
+                Width      = 492,
+                SortMode   = DataGridViewColumnSortMode.NotSortable,
+            };
+            _grid.Columns.AddRange(colName, colUrl);
+
+            var btnAdd    = new Button { Text = "Add",       Size = new Size(80, 26), Location = new Point(8,   442) };
+            var btnDelete = new Button { Text = "Delete",    Size = new Size(80, 26), Location = new Point(96,  442) };
+            var btnUp     = new Button { Text = "▲ Move Up", Size = new Size(88, 26), Location = new Point(184, 442) };
+            var btnDown   = new Button { Text = "▼ Move Down", Size = new Size(96, 26), Location = new Point(280, 442) };
+            var btnSave   = new Button { Text = "Save",      Size = new Size(80, 26), Location = new Point(520, 442), DialogResult = DialogResult.OK };
+            var btnCancel = new Button { Text = "Cancel",    Size = new Size(80, 26), Location = new Point(608, 442), DialogResult = DialogResult.Cancel };
+
+            btnAdd.Click    += BtnAdd_Click;
+            btnDelete.Click += BtnDelete_Click;
+            btnUp.Click     += BtnUp_Click;
+            btnDown.Click   += BtnDown_Click;
+            btnSave.Click   += BtnSave_Click;
+
+            Controls.AddRange(new Control[] { _grid, btnAdd, btnDelete, btnUp, btnDown, btnSave, btnCancel });
+            AcceptButton = btnSave;
+            CancelButton = btnCancel;
+        }
+
+        // ── File I/O ───────────────────────────────────────────────────────────
+
+        private void LoadFile()
+        {
+            _lines = new List<FileLine>();
+            _grid.Rows.Clear();
+
+            if (!File.Exists(_filePath))
+                return;
+
+            foreach (string raw in File.ReadAllLines(_filePath, Encoding.Default))
+            {
+                string trimmed = raw.Trim();
+                bool isEndpoint = !string.IsNullOrEmpty(trimmed)
+                                  && trimmed != "|"
+                                  && !trimmed.StartsWith("#");
+
+                if (isEndpoint)
+                {
+                    string[] parts = trimmed.Split(new char[] { '|' }, 2);
+                    string name = parts[0].Trim();
+                    string url  = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+                    _lines.Add(new FileLine { IsEndpoint = true, Name = name, Url = url });
+                    _grid.Rows.Add(name, url);
+                }
+                else
+                {
+                    _lines.Add(new FileLine { IsEndpoint = false, Raw = raw });
+                }
+            }
+        }
+
+        private void BtnSave_Click(object sender, EventArgs e)
+        {
+            // Commit any pending cell edit
+            _grid.EndEdit();
+
+            // Sync grid values back to the endpoint FileLine objects
+            int gridIdx = 0;
+            foreach (FileLine fl in _lines)
+            {
+                if (!fl.IsEndpoint)
+                    continue;
+                if (gridIdx < _grid.Rows.Count)
+                {
+                    fl.Name = (_grid.Rows[gridIdx].Cells[0].Value ?? string.Empty).ToString().Trim();
+                    fl.Url  = (_grid.Rows[gridIdx].Cells[1].Value ?? string.Empty).ToString().Trim();
+                    gridIdx++;
+                }
+            }
+
+            // Reconstruct the file
+            var sb = new StringBuilder();
+            foreach (FileLine fl in _lines)
+            {
+                if (fl.IsEndpoint)
+                {
+                    if (string.IsNullOrEmpty(fl.Name) && string.IsNullOrEmpty(fl.Url))
+                        continue;   // skip blank rows added then left empty
+                    sb.AppendLine(string.IsNullOrEmpty(fl.Name)
+                        ? fl.Url
+                        : fl.Name + "|" + fl.Url);
+                }
+                else
+                {
+                    sb.AppendLine(fl.Raw);
+                }
+            }
+
+            try
+            {
+                File.WriteAllText(_filePath, sb.ToString(), Encoding.Default);
+                FileWasModified = true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to save endpoint list:\n" + ex.Message,
+                                "Save Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                DialogResult = DialogResult.None;
+            }
+        }
+
+        // ── Grid toolbar ───────────────────────────────────────────────────────
+
+        private void BtnAdd_Click(object sender, EventArgs e)
+        {
+            int newRow = _grid.Rows.Add("New Endpoint", "http://");
+            _lines.Add(new FileLine { IsEndpoint = true, Name = "New Endpoint", Url = "http://" });
+            _grid.ClearSelection();
+            _grid.Rows[newRow].Selected = true;
+            _grid.CurrentCell = _grid.Rows[newRow].Cells[0];
+            _grid.BeginEdit(true);
+        }
+
+        private void BtnDelete_Click(object sender, EventArgs e)
+        {
+            if (_grid.CurrentRow == null)
+                return;
+            int gridRow = _grid.CurrentRow.Index;
+            _grid.Rows.RemoveAt(gridRow);
+            RemoveEndpointLine(gridRow);
+        }
+
+        private void BtnUp_Click(object sender, EventArgs e)
+        {
+            if (_grid.CurrentRow == null || _grid.CurrentRow.Index == 0)
+                return;
+            int idx = _grid.CurrentRow.Index;
+            SwapGridRows(idx, idx - 1);
+            SwapEndpointLines(idx, idx - 1);
+            _grid.ClearSelection();
+            _grid.Rows[idx - 1].Selected = true;
+        }
+
+        private void BtnDown_Click(object sender, EventArgs e)
+        {
+            if (_grid.CurrentRow == null || _grid.CurrentRow.Index >= _grid.Rows.Count - 1)
+                return;
+            int idx = _grid.CurrentRow.Index;
+            SwapGridRows(idx, idx + 1);
+            SwapEndpointLines(idx, idx + 1);
+            _grid.ClearSelection();
+            _grid.Rows[idx + 1].Selected = true;
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private void SwapGridRows(int a, int b)
+        {
+            var row = _grid.Rows[a];
+            object nameA = row.Cells[0].Value;
+            object urlA  = row.Cells[1].Value;
+            var rowB = _grid.Rows[b];
+            row.Cells[0].Value  = rowB.Cells[0].Value;
+            row.Cells[1].Value  = rowB.Cells[1].Value;
+            rowB.Cells[0].Value = nameA;
+            rowB.Cells[1].Value = urlA;
+        }
+
+        // Swap endpoint data at grid indices a and b within _lines (skipping comment lines).
+        private void SwapEndpointLines(int a, int b)
+        {
+            FileLine lineA = GetEndpointLine(a);
+            FileLine lineB = GetEndpointLine(b);
+            if (lineA == null || lineB == null)
+                return;
+            string tmpName = lineA.Name;
+            string tmpUrl  = lineA.Url;
+            lineA.Name = lineB.Name;
+            lineA.Url  = lineB.Url;
+            lineB.Name = tmpName;
+            lineB.Url  = tmpUrl;
+        }
+
+        private FileLine GetEndpointLine(int gridIndex)
+        {
+            int count = 0;
+            foreach (FileLine fl in _lines)
+            {
+                if (!fl.IsEndpoint)
+                    continue;
+                if (count == gridIndex)
+                    return fl;
+                count++;
+            }
+            return null;
+        }
+
+        private void RemoveEndpointLine(int gridIndex)
+        {
+            int count = 0;
+            for (int i = 0; i < _lines.Count; i++)
+            {
+                if (!_lines[i].IsEndpoint)
+                    continue;
+                if (count == gridIndex)
+                {
+                    _lines.RemoveAt(i);
+                    return;
+                }
+                count++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Closes #8** — Configuration dialog: replaces the old "open user.config in Notepad" menu item with a proper 5-tab settings form (Refresh & Notifications / Scan / Resolution / Export / Tools & API Keys). Reads all settings from \`Settings.Default\` on open; writes back and calls \`LoadConfiguration()\` on OK so runtime state is kept in sync.
- **Closes #9** — Endpoint Management dialog: replaces "open .txt in Notepad" with a \`DataGridView\` CRUD form. Supports Add, Delete, Move Up, Move Down. Comment and blank lines in the file are preserved on save. The main form reloads the endpoint list automatically when the file was changed.
- **Closes #35** — URL special-character handling was already fixed in the \`net10\` migration commit (\`Split(new char[] { '|' }, 2)\`). Closed on GitHub with an explanatory comment.
- **Supporting change** — \`ApplyDarkTheme(Control root)\` extracted as a \`public static\` helper on \`CheckerMainForm\` so both new dialogs get the premium dark theme without code duplication. \`DescendantControls()\` promoted to \`public static\`.

## Test plan

- [ ] Open **Settings → Configuration** — verify all 5 tabs show saved values; change a setting, click OK, confirm main form controls reflect the change
- [ ] Open **File → Endpoint List** — verify existing endpoints load into the grid; add a row, delete a row, move rows up/down, click Save — confirm the .txt is updated and the main list reloads
- [ ] Cancel the Endpoint Management dialog — confirm .txt is unchanged and no reload happens
- [ ] Verify dark theme is applied to both new dialogs
- [ ] Build with \`dotnet build\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)