### PR TITLE
Extract endpoint definition parser

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -1,0 +1,47 @@
+# Endpoint Status Checker v3 Refactoring Programme
+
+## Ticket 1: Endpoint loading and parsing
+
+Status: In progress on `refactor/v3-endpoint-definition-parser`
+
+Base branch: `v3-main`
+
+Objective:
+
+Extract endpoint-definition parsing and default `EndpointDefinition` creation from `CheckerMainForm.LoadEndpointReferences` into a narrow internal parser while preserving the current v3 loading behavior.
+
+Scope:
+
+- Parse raw endpoint-definition lines without WinForms controls, message boxes, settings, file I/O, global mutable state, network calls, or application state mutation.
+- Preserve blank/comment/lone-pipe ignored line handling.
+- Preserve first-pipe splitting for `Name|URL`.
+- Preserve duplicate-name detection semantics.
+- Preserve embedded credential extraction, credential removal from final address, and current endpoint-name modification.
+- Preserve URL escaping and protocol validation categories.
+- Preserve current default `EndpointDefinition` field initialization.
+- Keep file reading, progress labels, maximum endpoint-count handling, message boxes, last-seen restoration, disabled-state restoration, list refresh, and startup scan orchestration in `CheckerMainForm.LoadEndpointReferences`.
+
+Non-goals:
+
+- No HTTP, FTP, SSL, redirect, retry, Cloudflare, cancellation, export, or UI behavior changes.
+- No public API changes.
+- No dependency additions.
+- No work on Ticket 2 or later.
+
+Compatibility notes:
+
+- Maximum endpoint count remains based on source file line number, not valid endpoint count.
+- Duplicate detection remains ordinal and case-sensitive after the legacy trim/name normalization behavior.
+- A line can still contribute to both duplicate-name and invalid-URL user-visible error categories.
+- Unsupported protocol is reported only after the legacy `://` delimiter check succeeds.
+- `Uri.EscapeUriString` remains intentionally used to preserve byte-for-byte URL normalization behavior from the original loader.
+
+Tests:
+
+- `tests/EndpointDefinitionParser.Tests` is a dependency-free console characterization suite for the internal parser behavior.
+
+Verification:
+
+- `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
+- `dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true`
+- `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -4248,6 +4248,7 @@ namespace EndpointChecker
                 // CHECK DEFINITIONS FILE EXISTENCE
                 if (File.Exists(endpointDefinitionsFile))
                 {
+                    EndpointDefinitionParser endpointDefinitionParser = new EndpointDefinitionParser();
                     List<string> endpointDuplicityList = new List<string>();
                     List<string> invalidURLList = new List<string>();
 
@@ -4286,194 +4287,21 @@ namespace EndpointChecker
                             SetProgressStatus(0, 0,
                                 "Loading Endpoints References [" + lineNumber + "] ...", Color.Blue);
 
-                            // CHECK DEFINITION FOR NAME PARAMETER
-                            // Split on the FIRST pipe only so URLs containing '|' are preserved (issue #35)
-                            string[] lineParts = line.Split(new char[] { '|' }, 2);
-                            string lineAddress = lineParts.Length > 1 ? lineParts[1].Trim() : lineParts[0].Trim();
-                            string lineName    = lineParts[0].Trim();
+                            EndpointDefinitionParseResult parseResult = endpointDefinitionParser.ParseLine(line, lineNumber);
 
-                            // CREATE ENDPOINT STATUS DEFINITION
-                            EndpointDefinition endpointStatusDefiniton = new EndpointDefinition()
+                            if (parseResult.DuplicateError != null)
                             {
-                                Name = lineName,
-                                Protocol = status_NotAvailable,
-                                Port = status_NotAvailable,
-                                Address = lineAddress,
-                                ResponseAddress = lineAddress,
-                                IPAddress = new string[] { status_NotAvailable },
-                                ResponseTime = status_NotAvailable,
-                                ResponseCode = status_NotAvailable,
-                                ResponseMessage = GetEnumDescriptionString(EndpointStatus.NOTCHECKED),
-                                LastSeenOnline = status_NotAvailable,
-                                PingRoundtripTime = status_NotAvailable,
-                                ServerID = status_NotAvailable,
-                                LoginName = status_NotAvailable,
-                                LoginPass = status_NotAvailable,
-                                NetworkShare = new string[] { status_NotAvailable },
-                                DNSName = new string[] { status_NotAvailable },
-                                HTMLMetaInfo = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTTPautoRedirects = status_NotAvailable,
-                                HTTPcontentType = status_NotAvailable,
-                                HTTPencoding = null,
-                                HTMLdefaultStreamEncoding = null,
-                                HTMLencoding = null,
-                                HTMLTitle = status_NotAvailable,
-                                HTMLAuthor = status_NotAvailable,
-                                HTMLPageLinks = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTMLDescription = status_NotAvailable,
-                                HTMLContentLanguage = status_NotAvailable,
-                                HTMLThemeColor = Color.Empty,
-                                HTTPcontentLength = status_NotAvailable,
-                                HTTPexpires = status_NotAvailable,
-                                HTTPetag = status_NotAvailable,
-                                HTTPRequestHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTTPResponseHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
-                                MACAddress = new string[] { status_NotAvailable },
-                                FTPBannerMessage = status_NotAvailable,
-                                FTPWelcomeMessage = status_NotAvailable,
-                                FTPExitMessage = status_NotAvailable,
-                                FTPStatusDescription = status_NotAvailable,
-                                SSLCertificateProperties = new PropertyItems() { PropertyItem = new List<Property>() }
-                            };
-
-                            bool duplicityDefinition = false;
-                            bool invalidURL = false;
-
-                            // CHECK URL
-                            if (!endpointStatusDefiniton.Address.ToLower().Contains(Uri.SchemeDelimiter))
-                            {
-                                // URL FORMAT IS INVALID, ADD TO ERRORS LIST [MISSING PROTOCOL PREFIX]
-                                invalidURL = true;
-                                invalidURLList.Add(
-                                        "Line:  " + lineNumber +
-                                        Environment.NewLine +
-                                        "Endpoint Name:  " + endpointStatusDefiniton.Name +
-                                        Environment.NewLine +
-                                        "Endpoint Address:  " + endpointStatusDefiniton.Address +
-                                        Environment.NewLine +
-                                        "Missing protocol prefix" +
-                                        Environment.NewLine +
-                                        Uri.UriSchemeHttp.ToUpper() + ", " +
-                                        Uri.UriSchemeHttps.ToUpper() + " and " +
-                                        Uri.UriSchemeFtp.ToUpper() + " protocols are supported" +
-                                        Environment.NewLine +
-                                        Environment.NewLine
-                                    );
-                            }
-                            else
-                            {
-                                // GET CREDENTIALS FROM URL [IF PRESENT]
-                                if (endpointStatusDefiniton.Address.Contains("@"))
-                                {
-                                    string[] credentials = endpointStatusDefiniton.Address.Split('@')[0].Split('/')[2].Split(':');
-                                    if (credentials.Length == 2)
-                                    {
-                                        // EXTRACT
-                                        endpointStatusDefiniton.LoginName = credentials[0];
-                                        endpointStatusDefiniton.LoginPass = credentials[1];
-
-                                        // REMOVE CREDENTIALS FROM ENDPOINT NAME
-                                        // ADD USERNAME IDENTIFIER
-                                        endpointStatusDefiniton.Name = endpointStatusDefiniton.Name
-                                            .Replace(
-                                            endpointStatusDefiniton.LoginName + ":" +
-                                            endpointStatusDefiniton.LoginPass + "@", string.Empty) +
-                                            " [as '" + endpointStatusDefiniton.LoginName + "']";
-
-                                        // REMOVE CREDENTIALS FROM ENDPOINT ADDRESS
-                                        endpointStatusDefiniton.Address = endpointStatusDefiniton.Address
-                                            .Replace(endpointStatusDefiniton.LoginName + ":" +
-                                            endpointStatusDefiniton.LoginPass + "@", string.Empty);
-                                    }
-                                }
-
-                                try
-                                {
-                                    // Normalise special characters (e.g. commas, spaces) that are legal in
-                                    // URLs but cause Uri() to throw a UriFormatException (issue #35).
-                                    if (!Uri.IsWellFormedUriString(endpointStatusDefiniton.Address, UriKind.Absolute))
-                                    {
-                                        string escaped = Uri.EscapeUriString(endpointStatusDefiniton.Address);
-                                        if (Uri.IsWellFormedUriString(escaped, UriKind.Absolute))
-                                        {
-                                            endpointStatusDefiniton.Address = escaped;
-                                            endpointStatusDefiniton.ResponseAddress = escaped;
-                                        }
-                                    }
-
-                                    // CHECK URL FORMAT [TRY TO CREATE ENDPOINT URI]
-                                    Uri endpointURI = new Uri(endpointStatusDefiniton.Address, UriKind.Absolute);
-
-                                    // GET URI ATTRIBUTES
-                                    endpointStatusDefiniton.Port = endpointURI.Port.ToString();
-                                    endpointStatusDefiniton.Protocol = endpointURI.Scheme.ToUpper();
-
-                                    // CHECK SUPPORTED PROTOCOLS TYPES
-                                    if (endpointStatusDefiniton.Protocol != Uri.UriSchemeHttp.ToUpper() &&
-                                        endpointStatusDefiniton.Protocol != Uri.UriSchemeHttps.ToUpper() &&
-                                        endpointStatusDefiniton.Protocol != Uri.UriSchemeFtp.ToUpper())
-                                    {
-                                        // UNSUPPORTED PROTOCOL TYPE, ADD TO ERRORS LIST [UNSUPPORTED PROTOCOL TYPE]
-                                        invalidURL = true;
-                                        invalidURLList.Add(
-                                            "Line:  " + lineNumber +
-                                            Environment.NewLine +
-                                            "Endpoint Name:  " + endpointStatusDefiniton.Name +
-                                            Environment.NewLine +
-                                            "Endpoint Address:  " + endpointStatusDefiniton.Address +
-                                            Environment.NewLine +
-                                            "Unsupported protocol type: " + endpointStatusDefiniton.Protocol +
-                                            Environment.NewLine +
-                                            Uri.UriSchemeHttp.ToUpper() + ", " +
-                                            Uri.UriSchemeHttps.ToUpper() + " and " +
-                                            Uri.UriSchemeFtp.ToUpper() + " protocols are supported" +
-                                            Environment.NewLine +
-                                            Environment.NewLine
-                                        );
-                                    }
-                                }
-                                catch (Exception exception)
-                                {
-                                    // URL FORMAT IS INVALID, ADD TO ERRORS LIST [INVALID URL FORMAT]
-                                    invalidURL = true;
-                                    invalidURLList.Add(
-                                            "Line:  " + lineNumber +
-                                            Environment.NewLine +
-                                            "Endpoint Name:  " + endpointStatusDefiniton.Name +
-                                            Environment.NewLine +
-                                            "Endpoint Address:  " + endpointStatusDefiniton.Address +
-                                            Environment.NewLine +
-                                            "URL in invalid format" +
-                                            Environment.NewLine +
-                                            exception.Message +
-                                            Environment.NewLine +
-                                            Environment.NewLine
-                                        );
-                                }
+                                endpointDuplicityList.Add(parseResult.DuplicateError.ToDuplicateDisplayText());
                             }
 
-                            foreach (EndpointDefinition endpointDefinition in endpointsList)
+                            if (parseResult.InvalidUrlError != null)
                             {
-                                // CHECK ALL EXISTING DEFINITIONS FOR NAME DUPLICITY
-                                if (endpointDefinition.Name == endpointStatusDefiniton.Name)
-                                {
-                                    // DUPLICITY EXISTS, ADD TO ERRORS LIST [DUPLICITIES]
-                                    duplicityDefinition = true;
-                                    endpointDuplicityList.Add(
-                                        "Line:  " + lineNumber +
-                                        Environment.NewLine +
-                                        "Endpoint Name:  " + endpointStatusDefiniton.Name +
-                                        Environment.NewLine +
-                                        "Endpoint Address:  " + endpointStatusDefiniton.Address +
-                                        Environment.NewLine +
-                                        Environment.NewLine
-                                    );
-                                }
+                                invalidURLList.Add(parseResult.InvalidUrlError.ToInvalidUrlDisplayText());
                             }
-
-                            if (!duplicityDefinition &&
-                                !invalidURL)
+                            else if (parseResult.IsValid)
                             {
+                                EndpointDefinition endpointStatusDefiniton = parseResult.EndpointDefinition;
+
                                 // RESTORE 'LAST SEEN ONLINE' VALUE
                                 if (endpointsList_LastSeenOnline.ContainsKey(endpointStatusDefiniton.Name))
                                 {

--- a/src/EndpointDefinitionParser.cs
+++ b/src/EndpointDefinitionParser.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace EndpointChecker
+{
+    internal sealed class EndpointDefinitionParser
+    {
+        private const string StatusNotAvailable = "N/A";
+        private const string ResponseMessageNotCheckedYet = "Not Checked Yet";
+
+        private readonly List<string> endpointNames = new List<string>();
+
+        public EndpointDefinitionParser(IEnumerable<string> existingEndpointNames = null)
+        {
+            if (existingEndpointNames == null)
+            {
+                return;
+            }
+
+            foreach (string endpointName in existingEndpointNames)
+            {
+                endpointNames.Add(endpointName);
+            }
+        }
+
+        public EndpointDefinitionParseResult ParseLine(string rawLine, int lineNumber)
+        {
+            string line = rawLine == null ? string.Empty : rawLine.Trim();
+
+            if (string.IsNullOrEmpty(line) ||
+                line == "|" ||
+                line.StartsWith("#"))
+            {
+                return EndpointDefinitionParseResult.Ignored(lineNumber);
+            }
+
+            EndpointDefinition endpointDefinition = CreateDefaultEndpointDefinition(line);
+            EndpointDefinitionParseError invalidUrlError = ValidateAndNormalizeEndpoint(endpointDefinition, lineNumber);
+            EndpointDefinitionParseError duplicateError = null;
+
+            foreach (string endpointName in endpointNames)
+            {
+                if (endpointName == endpointDefinition.Name)
+                {
+                    duplicateError = EndpointDefinitionParseError.Duplicate(lineNumber, endpointDefinition);
+                }
+            }
+
+            if (duplicateError != null)
+            {
+                return EndpointDefinitionParseResult.Duplicate(endpointDefinition, duplicateError, invalidUrlError);
+            }
+
+            if (invalidUrlError != null)
+            {
+                return EndpointDefinitionParseResult.Invalid(endpointDefinition, invalidUrlError);
+            }
+
+            endpointNames.Add(endpointDefinition.Name);
+            return EndpointDefinitionParseResult.Valid(endpointDefinition);
+        }
+
+        internal static EndpointDefinition CreateDefaultEndpointDefinition(string line)
+        {
+            string[] lineParts = line.Split(new char[] { '|' }, 2);
+            string lineAddress = lineParts.Length > 1 ? lineParts[1].Trim() : lineParts[0].Trim();
+            string lineName = lineParts[0].Trim();
+
+            return new EndpointDefinition()
+            {
+                Name = lineName,
+                Protocol = StatusNotAvailable,
+                Port = StatusNotAvailable,
+                Address = lineAddress,
+                ResponseAddress = lineAddress,
+                IPAddress = new string[] { StatusNotAvailable },
+                ResponseTime = StatusNotAvailable,
+                ResponseCode = StatusNotAvailable,
+                ResponseMessage = ResponseMessageNotCheckedYet,
+                LastSeenOnline = StatusNotAvailable,
+                PingRoundtripTime = StatusNotAvailable,
+                ServerID = StatusNotAvailable,
+                LoginName = StatusNotAvailable,
+                LoginPass = StatusNotAvailable,
+                NetworkShare = new string[] { StatusNotAvailable },
+                DNSName = new string[] { StatusNotAvailable },
+                HTMLMetaInfo = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTTPautoRedirects = StatusNotAvailable,
+                HTTPcontentType = StatusNotAvailable,
+                HTTPencoding = null,
+                HTMLdefaultStreamEncoding = null,
+                HTMLencoding = null,
+                HTMLTitle = StatusNotAvailable,
+                HTMLAuthor = StatusNotAvailable,
+                HTMLPageLinks = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTMLDescription = StatusNotAvailable,
+                HTMLContentLanguage = StatusNotAvailable,
+                HTMLThemeColor = Color.Empty,
+                HTTPcontentLength = StatusNotAvailable,
+                HTTPexpires = StatusNotAvailable,
+                HTTPetag = StatusNotAvailable,
+                HTTPRequestHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTTPResponseHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
+                MACAddress = new string[] { StatusNotAvailable },
+                FTPBannerMessage = StatusNotAvailable,
+                FTPWelcomeMessage = StatusNotAvailable,
+                FTPExitMessage = StatusNotAvailable,
+                FTPStatusDescription = StatusNotAvailable,
+                SSLCertificateProperties = new PropertyItems() { PropertyItem = new List<Property>() }
+            };
+        }
+
+        private static EndpointDefinitionParseError ValidateAndNormalizeEndpoint(EndpointDefinition endpointDefinition, int lineNumber)
+        {
+            if (!endpointDefinition.Address.ToLower().Contains(Uri.SchemeDelimiter))
+            {
+                return EndpointDefinitionParseError.MissingProtocol(lineNumber, endpointDefinition);
+            }
+
+            ExtractCredentials(endpointDefinition);
+
+            try
+            {
+                if (!Uri.IsWellFormedUriString(endpointDefinition.Address, UriKind.Absolute))
+                {
+                    string escaped = Uri.EscapeUriString(endpointDefinition.Address);
+                    if (Uri.IsWellFormedUriString(escaped, UriKind.Absolute))
+                    {
+                        endpointDefinition.Address = escaped;
+                        endpointDefinition.ResponseAddress = escaped;
+                    }
+                }
+
+                Uri endpointURI = new Uri(endpointDefinition.Address, UriKind.Absolute);
+
+                endpointDefinition.Port = endpointURI.Port.ToString();
+                endpointDefinition.Protocol = endpointURI.Scheme.ToUpper();
+
+                if (endpointDefinition.Protocol != Uri.UriSchemeHttp.ToUpper() &&
+                    endpointDefinition.Protocol != Uri.UriSchemeHttps.ToUpper() &&
+                    endpointDefinition.Protocol != Uri.UriSchemeFtp.ToUpper())
+                {
+                    return EndpointDefinitionParseError.UnsupportedProtocol(lineNumber, endpointDefinition);
+                }
+            }
+            catch (Exception exception)
+            {
+                return EndpointDefinitionParseError.InvalidFormat(lineNumber, endpointDefinition, exception.Message);
+            }
+
+            return null;
+        }
+
+        private static void ExtractCredentials(EndpointDefinition endpointDefinition)
+        {
+            if (!endpointDefinition.Address.Contains("@"))
+            {
+                return;
+            }
+
+            string[] credentials = endpointDefinition.Address.Split('@')[0].Split('/')[2].Split(':');
+            if (credentials.Length != 2)
+            {
+                return;
+            }
+
+            endpointDefinition.LoginName = credentials[0];
+            endpointDefinition.LoginPass = credentials[1];
+
+            endpointDefinition.Name = endpointDefinition.Name
+                .Replace(
+                endpointDefinition.LoginName + ":" +
+                endpointDefinition.LoginPass + "@", string.Empty) +
+                " [as '" + endpointDefinition.LoginName + "']";
+
+            endpointDefinition.Address = endpointDefinition.Address
+                .Replace(endpointDefinition.LoginName + ":" +
+                endpointDefinition.LoginPass + "@", string.Empty);
+        }
+    }
+
+    internal sealed class EndpointDefinitionParseResult
+    {
+        private EndpointDefinitionParseResult(
+            EndpointDefinitionParseStatus status,
+            EndpointDefinition endpointDefinition,
+            EndpointDefinitionParseError invalidUrlError,
+            EndpointDefinitionParseError duplicateError,
+            int lineNumber)
+        {
+            Status = status;
+            EndpointDefinition = endpointDefinition;
+            InvalidUrlError = invalidUrlError;
+            DuplicateError = duplicateError;
+            LineNumber = lineNumber;
+        }
+
+        public EndpointDefinitionParseStatus Status { get; }
+        public EndpointDefinition EndpointDefinition { get; }
+        public EndpointDefinitionParseError Error => DuplicateError ?? InvalidUrlError;
+        public EndpointDefinitionParseError InvalidUrlError { get; }
+        public EndpointDefinitionParseError DuplicateError { get; }
+        public int LineNumber { get; }
+        public bool IsIgnored => Status == EndpointDefinitionParseStatus.Ignored;
+        public bool IsValid => Status == EndpointDefinitionParseStatus.Valid;
+
+        public static EndpointDefinitionParseResult Ignored(int lineNumber)
+        {
+            return new EndpointDefinitionParseResult(EndpointDefinitionParseStatus.Ignored, null, null, null, lineNumber);
+        }
+
+        public static EndpointDefinitionParseResult Valid(EndpointDefinition endpointDefinition)
+        {
+            return new EndpointDefinitionParseResult(EndpointDefinitionParseStatus.Valid, endpointDefinition, null, null, 0);
+        }
+
+        public static EndpointDefinitionParseResult Invalid(EndpointDefinition endpointDefinition, EndpointDefinitionParseError error)
+        {
+            return new EndpointDefinitionParseResult(EndpointDefinitionParseStatus.InvalidUrl, endpointDefinition, error, null, error.LineNumber);
+        }
+
+        public static EndpointDefinitionParseResult Duplicate(
+            EndpointDefinition endpointDefinition,
+            EndpointDefinitionParseError duplicateError,
+            EndpointDefinitionParseError invalidUrlError)
+        {
+            return new EndpointDefinitionParseResult(EndpointDefinitionParseStatus.Duplicate, endpointDefinition, invalidUrlError, duplicateError, duplicateError.LineNumber);
+        }
+    }
+
+    internal enum EndpointDefinitionParseStatus
+    {
+        Ignored,
+        Valid,
+        InvalidUrl,
+        Duplicate
+    }
+
+    internal sealed class EndpointDefinitionParseError
+    {
+        private EndpointDefinitionParseError(
+            EndpointDefinitionParseErrorKind kind,
+            int lineNumber,
+            string endpointName,
+            string endpointAddress,
+            string detail)
+        {
+            Kind = kind;
+            LineNumber = lineNumber;
+            EndpointName = endpointName;
+            EndpointAddress = endpointAddress;
+            Detail = detail;
+        }
+
+        public EndpointDefinitionParseErrorKind Kind { get; }
+        public int LineNumber { get; }
+        public string EndpointName { get; }
+        public string EndpointAddress { get; }
+        public string Detail { get; }
+
+        public static EndpointDefinitionParseError MissingProtocol(int lineNumber, EndpointDefinition endpointDefinition)
+        {
+            return new EndpointDefinitionParseError(
+                EndpointDefinitionParseErrorKind.MissingProtocol,
+                lineNumber,
+                endpointDefinition.Name,
+                endpointDefinition.Address,
+                "Missing protocol prefix");
+        }
+
+        public static EndpointDefinitionParseError UnsupportedProtocol(int lineNumber, EndpointDefinition endpointDefinition)
+        {
+            return new EndpointDefinitionParseError(
+                EndpointDefinitionParseErrorKind.UnsupportedProtocol,
+                lineNumber,
+                endpointDefinition.Name,
+                endpointDefinition.Address,
+                "Unsupported protocol type: " + endpointDefinition.Protocol);
+        }
+
+        public static EndpointDefinitionParseError InvalidFormat(int lineNumber, EndpointDefinition endpointDefinition, string exceptionMessage)
+        {
+            return new EndpointDefinitionParseError(
+                EndpointDefinitionParseErrorKind.InvalidFormat,
+                lineNumber,
+                endpointDefinition.Name,
+                endpointDefinition.Address,
+                "URL in invalid format" + Environment.NewLine + exceptionMessage);
+        }
+
+        public static EndpointDefinitionParseError Duplicate(int lineNumber, EndpointDefinition endpointDefinition)
+        {
+            return new EndpointDefinitionParseError(
+                EndpointDefinitionParseErrorKind.DuplicateName,
+                lineNumber,
+                endpointDefinition.Name,
+                endpointDefinition.Address,
+                null);
+        }
+
+        public string ToInvalidUrlDisplayText()
+        {
+            string message =
+                "Line:  " + LineNumber +
+                Environment.NewLine +
+                "Endpoint Name:  " + EndpointName +
+                Environment.NewLine +
+                "Endpoint Address:  " + EndpointAddress +
+                Environment.NewLine +
+                Detail +
+                Environment.NewLine;
+
+            if (Kind == EndpointDefinitionParseErrorKind.MissingProtocol ||
+                Kind == EndpointDefinitionParseErrorKind.UnsupportedProtocol)
+            {
+                message +=
+                    Uri.UriSchemeHttp.ToUpper() + ", " +
+                    Uri.UriSchemeHttps.ToUpper() + " and " +
+                    Uri.UriSchemeFtp.ToUpper() + " protocols are supported" +
+                    Environment.NewLine;
+            }
+
+            return message + Environment.NewLine;
+        }
+
+        public string ToDuplicateDisplayText()
+        {
+            return
+                "Line:  " + LineNumber +
+                Environment.NewLine +
+                "Endpoint Name:  " + EndpointName +
+                Environment.NewLine +
+                "Endpoint Address:  " + EndpointAddress +
+                Environment.NewLine +
+                Environment.NewLine;
+        }
+    }
+
+    internal enum EndpointDefinitionParseErrorKind
+    {
+        MissingProtocol,
+        UnsupportedProtocol,
+        InvalidFormat,
+        DuplicateName
+    }
+}

--- a/tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
+++ b/tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointDefinitionParser.cs" Link="EndpointDefinitionParser.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/EndpointDefinitionParser.Tests/EndpointDefinitionParserTests.cs
+++ b/tests/EndpointDefinitionParser.Tests/EndpointDefinitionParserTests.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+
+namespace EndpointChecker
+{
+    internal static class EndpointDefinitionParserTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("Blank lines are ignored", BlankLinesAreIgnored);
+            Run("Comment lines are ignored", CommentLinesAreIgnored);
+            Run("Lone pipe is ignored", LonePipeIsIgnored);
+            Run("Name URL splits on first pipe only", NameUrlSplitsOnFirstPipeOnly);
+            Run("URL without protocol is rejected as missing protocol", UrlWithoutProtocolIsRejectedAsMissingProtocol);
+            Run("Unsupported schemes are rejected", UnsupportedSchemesAreRejected);
+            Run("Duplicate endpoint names use ordinal current comparison", DuplicateEndpointNamesUseOrdinalComparison);
+            Run("Duplicate invalid lines report both legacy categories", DuplicateInvalidLinesReportBothLegacyCategories);
+            Run("Credentials are extracted from URL", CredentialsAreExtractedFromUrl);
+            Run("Credentials are removed from endpoint address", CredentialsAreRemovedFromEndpointAddress);
+            Run("Credential endpoint name behavior is preserved", CredentialEndpointNameBehaviorIsPreserved);
+            Run("URI escaping normalization is preserved", UriEscapingNormalizationIsPreserved);
+            Run("Default endpoint values are preserved", DefaultEndpointValuesArePreserved);
+            Run("Last seen restoration remains orchestration responsibility", LastSeenRestorationRemainsOrchestrationResponsibility);
+            Run("Maximum endpoint count remains line number based orchestration", MaximumEndpointCountRemainsLineNumberBasedOrchestration);
+            Run("Duplicate names differing by case whitespace normalization are preserved", DuplicateNamesDifferingByCaseWhitespaceNormalizationArePreserved);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void BlankLinesAreIgnored()
+        {
+            AssertEqual(EndpointDefinitionParseStatus.Ignored, new EndpointDefinitionParser().ParseLine("   ", 1).Status);
+        }
+
+        private static void CommentLinesAreIgnored()
+        {
+            AssertEqual(EndpointDefinitionParseStatus.Ignored, new EndpointDefinitionParser().ParseLine("  # comment", 1).Status);
+        }
+
+        private static void LonePipeIsIgnored()
+        {
+            AssertEqual(EndpointDefinitionParseStatus.Ignored, new EndpointDefinitionParser().ParseLine(" | ", 1).Status);
+        }
+
+        private static void NameUrlSplitsOnFirstPipeOnly()
+        {
+            EndpointDefinitionParseResult result = new EndpointDefinitionParser().ParseLine("Pipe Test|http://example.com/a|b", 7);
+
+            AssertEqual(EndpointDefinitionParseStatus.Valid, result.Status);
+            AssertEqual("Pipe Test", result.EndpointDefinition.Name);
+            AssertEqual("http://example.com/a%7Cb", result.EndpointDefinition.Address);
+            AssertEqual("http://example.com/a%7Cb", result.EndpointDefinition.ResponseAddress);
+        }
+
+        private static void UrlWithoutProtocolIsRejectedAsMissingProtocol()
+        {
+            EndpointDefinitionParseResult result = new EndpointDefinitionParser().ParseLine("Missing|example.com", 3);
+
+            AssertEqual(EndpointDefinitionParseStatus.InvalidUrl, result.Status);
+            AssertEqual(EndpointDefinitionParseErrorKind.MissingProtocol, result.Error.Kind);
+            AssertContains("Missing protocol prefix", result.Error.ToInvalidUrlDisplayText());
+        }
+
+        private static void UnsupportedSchemesAreRejected()
+        {
+            EndpointDefinitionParseResult result = new EndpointDefinitionParser().ParseLine("SSH|ssh://example.com", 4);
+
+            AssertEqual(EndpointDefinitionParseStatus.InvalidUrl, result.Status);
+            AssertEqual(EndpointDefinitionParseErrorKind.UnsupportedProtocol, result.Error.Kind);
+            AssertContains("Unsupported protocol type: SSH", result.Error.ToInvalidUrlDisplayText());
+        }
+
+        private static void DuplicateEndpointNamesUseOrdinalComparison()
+        {
+            EndpointDefinitionParser parser = new EndpointDefinitionParser();
+
+            AssertEqual(EndpointDefinitionParseStatus.Valid, parser.ParseLine("Same|http://example.com", 1).Status);
+            EndpointDefinitionParseResult duplicate = parser.ParseLine("Same|http://example.org", 2);
+
+            AssertEqual(EndpointDefinitionParseStatus.Duplicate, duplicate.Status);
+            AssertEqual(EndpointDefinitionParseErrorKind.DuplicateName, duplicate.Error.Kind);
+        }
+
+        private static void DuplicateInvalidLinesReportBothLegacyCategories()
+        {
+            EndpointDefinitionParser parser = new EndpointDefinitionParser();
+
+            AssertEqual(EndpointDefinitionParseStatus.Valid, parser.ParseLine("Same|http://example.com", 1).Status);
+            EndpointDefinitionParseResult duplicate = parser.ParseLine("Same|example.org", 2);
+
+            AssertEqual(EndpointDefinitionParseStatus.Duplicate, duplicate.Status);
+            AssertEqual(EndpointDefinitionParseErrorKind.DuplicateName, duplicate.DuplicateError.Kind);
+            AssertEqual(EndpointDefinitionParseErrorKind.MissingProtocol, duplicate.InvalidUrlError.Kind);
+        }
+
+        private static void CredentialsAreExtractedFromUrl()
+        {
+            EndpointDefinition endpoint = new EndpointDefinitionParser()
+                .ParseLine("Secure|http://user:pass@example.com/private", 1)
+                .EndpointDefinition;
+
+            AssertEqual("user", endpoint.LoginName);
+            AssertEqual("pass", endpoint.LoginPass);
+        }
+
+        private static void CredentialsAreRemovedFromEndpointAddress()
+        {
+            EndpointDefinition endpoint = new EndpointDefinitionParser()
+                .ParseLine("Secure|http://user:pass@example.com/private", 1)
+                .EndpointDefinition;
+
+            AssertEqual("http://example.com/private", endpoint.Address);
+        }
+
+        private static void CredentialEndpointNameBehaviorIsPreserved()
+        {
+            EndpointDefinition endpoint = new EndpointDefinitionParser()
+                .ParseLine("http://user:pass@example.com|http://user:pass@example.com", 1)
+                .EndpointDefinition;
+
+            AssertEqual("http://example.com [as 'user']", endpoint.Name);
+        }
+
+        private static void UriEscapingNormalizationIsPreserved()
+        {
+            EndpointDefinition endpoint = new EndpointDefinitionParser()
+                .ParseLine("Escaped|http://example.com/a path?q=hello world", 1)
+                .EndpointDefinition;
+
+            AssertEqual("http://example.com/a%20path?q=hello%20world", endpoint.Address);
+            AssertEqual("http://example.com/a%20path?q=hello%20world", endpoint.ResponseAddress);
+        }
+
+        private static void DefaultEndpointValuesArePreserved()
+        {
+            EndpointDefinition endpoint = EndpointDefinitionParser.CreateDefaultEndpointDefinition("Defaults|http://example.com");
+
+            AssertEqual("Defaults", endpoint.Name);
+            AssertEqual("http://example.com", endpoint.Address);
+            AssertEqual("http://example.com", endpoint.ResponseAddress);
+            AssertEqual("N/A", endpoint.Protocol);
+            AssertEqual("N/A", endpoint.Port);
+            AssertArray(new[] { "N/A" }, endpoint.IPAddress);
+            AssertEqual("N/A", endpoint.ResponseTime);
+            AssertEqual("N/A", endpoint.ResponseCode);
+            AssertEqual("Not Checked Yet", endpoint.ResponseMessage);
+            AssertEqual("N/A", endpoint.LastSeenOnline);
+            AssertEqual("N/A", endpoint.PingRoundtripTime);
+            AssertEqual("N/A", endpoint.ServerID);
+            AssertEqual("N/A", endpoint.LoginName);
+            AssertEqual("N/A", endpoint.LoginPass);
+            AssertArray(new[] { "N/A" }, endpoint.NetworkShare);
+            AssertArray(new[] { "N/A" }, endpoint.DNSName);
+            AssertEqual(0, endpoint.HTMLMetaInfo.PropertyItem.Count);
+            AssertEqual("N/A", endpoint.HTTPautoRedirects);
+            AssertEqual("N/A", endpoint.HTTPcontentType);
+            AssertEqual(null, endpoint.HTTPencoding);
+            AssertEqual(null, endpoint.HTMLdefaultStreamEncoding);
+            AssertEqual(null, endpoint.HTMLencoding);
+            AssertEqual("N/A", endpoint.HTMLTitle);
+            AssertEqual("N/A", endpoint.HTMLAuthor);
+            AssertEqual(0, endpoint.HTMLPageLinks.PropertyItem.Count);
+            AssertEqual("N/A", endpoint.HTMLDescription);
+            AssertEqual("N/A", endpoint.HTMLContentLanguage);
+            AssertEqual(Color.Empty, endpoint.HTMLThemeColor);
+            AssertEqual("N/A", endpoint.HTTPcontentLength);
+            AssertEqual("N/A", endpoint.HTTPexpires);
+            AssertEqual("N/A", endpoint.HTTPetag);
+            AssertEqual(0, endpoint.HTTPRequestHeaders.PropertyItem.Count);
+            AssertEqual(0, endpoint.HTTPResponseHeaders.PropertyItem.Count);
+            AssertArray(new[] { "N/A" }, endpoint.MACAddress);
+            AssertEqual("N/A", endpoint.FTPBannerMessage);
+            AssertEqual("N/A", endpoint.FTPWelcomeMessage);
+            AssertEqual("N/A", endpoint.FTPExitMessage);
+            AssertEqual("N/A", endpoint.FTPStatusDescription);
+            AssertEqual(0, endpoint.SSLCertificateProperties.PropertyItem.Count);
+        }
+
+        private static void LastSeenRestorationRemainsOrchestrationResponsibility()
+        {
+            Dictionary<string, string> lastSeen = new Dictionary<string, string>
+            {
+                { "Endpoint", "2026-08-02 10:15:00" }
+            };
+
+            EndpointDefinition endpoint = new EndpointDefinitionParser()
+                .ParseLine("Endpoint|http://example.com", 1)
+                .EndpointDefinition;
+
+            if (lastSeen.ContainsKey(endpoint.Name))
+            {
+                endpoint.LastSeenOnline = lastSeen[endpoint.Name];
+            }
+
+            AssertEqual("2026-08-02 10:15:00", endpoint.LastSeenOnline);
+        }
+
+        private static void MaximumEndpointCountRemainsLineNumberBasedOrchestration()
+        {
+            int maximum = 2;
+            int loaded = 0;
+
+            string[] lines =
+            {
+                "# comment",
+                "First|http://example.com",
+                "Second|http://example.org"
+            };
+
+            EndpointDefinitionParser parser = new EndpointDefinitionParser();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                int lineNumber = i + 1;
+                if (lineNumber > maximum)
+                {
+                    break;
+                }
+
+                if (parser.ParseLine(lines[i], lineNumber).IsValid)
+                {
+                    loaded++;
+                }
+            }
+
+            AssertEqual(1, loaded);
+        }
+
+        private static void DuplicateNamesDifferingByCaseWhitespaceNormalizationArePreserved()
+        {
+            EndpointDefinitionParser parser = new EndpointDefinitionParser();
+
+            AssertEqual(EndpointDefinitionParseStatus.Valid, parser.ParseLine("Name|http://example.com", 1).Status);
+            AssertEqual(EndpointDefinitionParseStatus.Valid, parser.ParseLine("name|http://example.org", 2).Status);
+            AssertEqual(EndpointDefinitionParseStatus.Duplicate, parser.ParseLine(" Name |http://example.net", 3).Status);
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+
+        private static void AssertArray(string[] expected, string[] actual)
+        {
+            if (!expected.SequenceEqual(actual))
+            {
+                throw new InvalidOperationException("Expected <" + string.Join(",", expected) + "> but was <" + string.Join(",", actual) + ">.");
+            }
+        }
+
+        private static void AssertContains(string expected, string actual)
+        {
+            if (actual == null || !actual.Contains(expected))
+            {
+                throw new InvalidOperationException("Expected text containing <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+
+    public class EndpointDefinition
+    {
+        public string Name { get; set; }
+        public string Protocol { get; set; }
+        public string Port { get; set; }
+        public string Address { get; set; }
+        public string ResponseAddress { get; set; }
+        public string[] IPAddress { get; set; }
+        public string ResponseTime { get; set; }
+        public string ResponseCode { get; set; }
+        public string ResponseMessage { get; set; }
+        public string PingRoundtripTime { get; set; }
+        public string ServerID { get; set; }
+        public string LoginName { get; set; }
+        public string LoginPass { get; set; }
+        public string[] NetworkShare { get; set; }
+        public string[] DNSName { get; set; }
+        public PropertyItems HTMLMetaInfo { get; set; }
+        public string HTTPautoRedirects { get; set; }
+        public string HTTPcontentType { get; set; }
+        public string HTTPcontentLength { get; set; }
+        public string HTTPexpires { get; set; }
+        public string HTTPetag { get; set; }
+        public Encoding HTTPencoding { get; set; }
+        public Encoding HTMLencoding { get; set; }
+        public Encoding HTMLdefaultStreamEncoding { get; set; }
+        public string HTMLTitle { get; set; }
+        public string HTMLAuthor { get; set; }
+        public string HTMLDescription { get; set; }
+        public string HTMLContentLanguage { get; set; }
+        public Color HTMLThemeColor { get; set; }
+        public PropertyItems HTTPRequestHeaders { get; set; }
+        public PropertyItems HTTPResponseHeaders { get; set; }
+        public string[] MACAddress { get; set; }
+        public string FTPBannerMessage { get; set; }
+        public string FTPWelcomeMessage { get; set; }
+        public string FTPExitMessage { get; set; }
+        public string FTPStatusDescription { get; set; }
+        public string LastSeenOnline { get; set; }
+        public PropertyItems SSLCertificateProperties { get; set; }
+        public PropertyItems HTMLPageLinks { get; set; }
+    }
+
+    public class Property
+    {
+        public string ItemName { get; set; }
+        public string ItemValue { get; set; }
+    }
+
+    public class PropertyItems
+    {
+        public List<Property> PropertyItem { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract endpoint definition parsing/default initialization from CheckerMainForm.LoadEndpointReferences into a narrow internal parser
- Keep file I/O, UI messaging, max-count handling, last-seen restoration, disabled-state restoration, and list refresh in the form
- Add dependency-free characterization tests for the parser and document Ticket 1 status

## Preserved legacy behavior
- blank/comment/lone-pipe lines are ignored
- Name|URL splits on the first pipe only
- duplicate comparison remains ordinal/case-sensitive after trim behavior
- duplicate invalid lines still report both duplicate and invalid URL categories
- embedded credentials are extracted, removed from final address, and alter the endpoint name as before
- URI escaping uses the same legacy Uri.EscapeUriString behavior
- no HTTP, FTP, SSL, redirect, Cloudflare, cancellation, retry, export, or UI behavior changed

## Verification
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj: passed
- dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true: passed with NU1900 warning due vulnerability-data source access
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true: passed with existing warnings
- dotnet format src/EndpointChecker.csproj --verify-no-changes --no-restore --verbosity minimal: failed on broad pre-existing whitespace issues across existing files