### PR TITLE
Extract endpoint checking core state

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -2,7 +2,7 @@
 
 ## Ticket 1: Endpoint loading and parsing
 
-Status: In progress on `refactor/v3-endpoint-definition-parser`
+Status: Merged to `v3-main` via PR #44
 
 Base branch: `v3-main`
 
@@ -44,4 +44,45 @@ Verification:
 
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true`
+- `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true`
+
+## Ticket 2: Endpoint checking core extraction
+
+Status: In progress on `refactor/v3-endpoint-checking-core`
+
+Base branch: `v3-main`
+
+Objective:
+
+Reduce the responsibility of `CheckerMainForm.bw_GetStatus_DoWork` by extracting behavior-preserving internal check-core boundaries that are deterministic and testable without changing network or UI behavior.
+
+Scope completed in this ticket:
+
+- Extracted an `EndpointCheckOptions` snapshot from WinForms control values.
+- Preserved UI timeout unit conversion from seconds to milliseconds.
+- Preserved thread-count adjustment based on enabled endpoint count.
+- Extracted per-endpoint pending check-result initialization.
+- Extracted top-level unhandled endpoint exception result mapping.
+- Added dependency-free characterization tests for these extracted boundaries.
+
+Non-goals:
+
+- No replacement of `HttpWebRequest`.
+- No change to HTTP request headers, cookies, authentication, redirects, retries, SSL, Cloudflare, timeout, cancellation, FTP, DNS, MAC, ping, export, or UI behavior.
+- No move of `BackgroundWorker` orchestration.
+
+Compatibility notes:
+
+- The result factory intentionally preserves the current `N/A`, `ERROR`, and `Not Checked Yet` strings.
+- The unhandled exception mapping intentionally preserves `ExceptionType -> message` response text.
+- The extracted options object preserves existing timeout multiplication and thread-count reduction behavior.
+
+Tests:
+
+- `tests/EndpointCheckingCore.Tests` covers the new options snapshot and check-result factory boundaries.
+
+Verification:
+
+- `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`
+- `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -655,40 +655,26 @@ namespace EndpointChecker
                 // UI control properties are captured on the UI thread via ThreadSafeInvoke
                 // to avoid cross-thread violations under .NET 5+ strict enforcement.
                 ConcurrentBag<EndpointDefinition> updatedEndpointsList = new ConcurrentBag<EndpointDefinition>();
-                bool autoRedirect_Enable      = false;
-                bool validateSSLCertificate   = false;
-                bool autoAdjustRefreshTimer   = false;
-                bool resolveNetworkShares     = false;
-                bool resolvePageMetaInfo      = false;
-                bool removeURLParameters      = false;
-                bool resolvePageLinks         = false;
-                bool saveResponse             = false;
-                bool testPing                 = false;
-                bool resolveDNSNames          = false;
-                bool resolveIPAddresses       = false;
-                bool resolveMACAddresses      = false;
-                int  threadsCount             = 1;
-                int  pingTimeout              = 3000;
-                int  httpRequestTimeout       = 30000;
-                int  ftpRequestTimeout        = 30000;
+                EndpointCheckOptions checkOptions = null;
                 ThreadSafeInvoke(() =>
                 {
-                    autoRedirect_Enable    = cb_AllowAutoRedirect.Checked;
-                    validateSSLCertificate = cb_ValidateSSLCertificate.Checked;
-                    autoAdjustRefreshTimer = cb_RefreshAutoSet.Checked;
-                    resolveNetworkShares   = cb_ResolveNetworkShares.Checked;
-                    resolvePageMetaInfo    = cb_ResolvePageMetaInfo.Checked;
-                    removeURLParameters    = cb_RemoveURLParameters.Checked;
-                    resolvePageLinks       = cb_ResolvePageLinks.Checked;
-                    saveResponse           = cb_SaveResponse.Checked;
-                    testPing               = cb_TestPing.Checked;
-                    resolveDNSNames        = cb_Resolve_DNS_Names.Checked;
-                    resolveIPAddresses     = cb_Resolve_IPAddresses.Checked;
-                    resolveMACAddresses    = cb_Resolve_NIC_MACs.Checked;
-                    threadsCount           = (int)num_ParallelThreadsCount.Value;
-                    pingTimeout            = (int)num_PingTimeout.Value * 1000;
-                    httpRequestTimeout     = (int)num_HTTPRequestTimeout.Value * 1000;
-                    ftpRequestTimeout      = (int)num_FTPRequestTimeout.Value * 1000;
+                    checkOptions = EndpointCheckOptions.FromUiValues(
+                        cb_AllowAutoRedirect.Checked,
+                        cb_ValidateSSLCertificate.Checked,
+                        cb_RefreshAutoSet.Checked,
+                        cb_ResolveNetworkShares.Checked,
+                        cb_ResolvePageMetaInfo.Checked,
+                        cb_RemoveURLParameters.Checked,
+                        cb_ResolvePageLinks.Checked,
+                        cb_SaveResponse.Checked,
+                        cb_TestPing.Checked,
+                        cb_Resolve_DNS_Names.Checked,
+                        cb_Resolve_IPAddresses.Checked,
+                        cb_Resolve_NIC_MACs.Checked,
+                        (int)num_ParallelThreadsCount.Value,
+                        (int)num_PingTimeout.Value,
+                        (int)num_HTTPRequestTimeout.Value,
+                        (int)num_FTPRequestTimeout.Value);
                 });
 
                 int endpointsCount_Current = 0;
@@ -708,7 +694,7 @@ namespace EndpointChecker
                 // FLUSH LOCAL DNS CACHE
                 DnsFlushResolverCache();
 
-                if (validateSSLCertificate)
+                if (checkOptions.ValidateSslCertificate)
                 {   // VALIDATE SERVER CERTIFICATE [HTTPS]
                     ServicePointManager.ServerCertificateValidationCallback = null;
                 }
@@ -719,11 +705,7 @@ namespace EndpointChecker
                 }
 
                 // ADJUST THREADS COUNT SETTING BY ENABLED ITEMS COUNT [IF LESS]
-                if (endpointsCount_Enabled > 0 &&
-                    endpointsCount_Enabled < threadsCount)
-                {
-                    threadsCount = endpointsCount_Enabled;
-                }
+                checkOptions = checkOptions.WithThreadCountAdjustedForEnabledEndpoints(endpointsCount_Enabled);
 
                 // STORE PROGRESS START DATE/TIME [FOR 'EXPORT' AND 'AUTO ADJUST REFRESH INTERVAL' PURPOSES]
                 DateTime startDT_List = DateTime.Now;
@@ -731,7 +713,7 @@ namespace EndpointChecker
                 // EXECUTE PARALLEL PROCESS 
                 Parallel.ForEach(
                     endpointsList,
-                    new ParallelOptions { MaxDegreeOfParallelism = threadsCount },
+                    new ParallelOptions { MaxDegreeOfParallelism = checkOptions.ThreadsCount },
                     endpointItem =>
                     {
                         if (!endpointItem.Name.ToLower().Contains(listFilter))
@@ -749,46 +731,7 @@ namespace EndpointChecker
                             Uri responseURI = new Uri(endpointItem.ResponseAddress);
                             string durationTime_Item = status_NotAvailable;
 
-                            EndpointDefinition endpoint = new EndpointDefinition()
-                            {
-                                Name = endpointItem.Name,
-                                Address = endpointItem.Address,
-                                Protocol = endpointItem.Protocol,
-                                Port = endpointItem.Port,
-                                IPAddress = new string[] { status_NotAvailable },
-                                DNSName = new string[] { status_NotAvailable },
-                                ResponseTime = status_NotAvailable,
-                                ResponseCode = status_NotAvailable,
-                                ResponseMessage = GetEnumDescriptionString(EndpointStatus.NOTCHECKED),
-                                LastSeenOnline = endpointItem.LastSeenOnline,
-                                PingRoundtripTime = status_NotAvailable,
-                                ServerID = status_NotAvailable,
-                                LoginName = endpointItem.LoginName,
-                                LoginPass = endpointItem.LoginPass,
-                                NetworkShare = new string[] { status_NotAvailable },
-                                HTMLMetaInfo = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTTPautoRedirects = status_NotAvailable,
-                                HTTPcontentType = status_NotAvailable,
-                                HTTPencoding = null,
-                                HTMLencoding = null,
-                                HTMLTitle = status_NotAvailable,
-                                HTMLAuthor = status_NotAvailable,
-                                HTMLDescription = status_NotAvailable,
-                                HTMLContentLanguage = status_NotAvailable,
-                                HTMLThemeColor = Color.Empty,
-                                HTMLPageLinks = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTTPcontentLength = status_NotAvailable,
-                                HTTPexpires = status_NotAvailable,
-                                HTTPetag = status_NotAvailable,
-                                HTTPRequestHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
-                                HTTPResponseHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
-                                MACAddress = new string[] { status_NotAvailable },
-                                FTPBannerMessage = status_NotAvailable,
-                                FTPWelcomeMessage = status_NotAvailable,
-                                FTPExitMessage = status_NotAvailable,
-                                FTPStatusDescription = status_NotAvailable,
-                                SSLCertificateProperties = new PropertyItems() { PropertyItem = new List<Property>() }
-                            };
+                            EndpointDefinition endpoint = EndpointCheckResultFactory.CreatePendingResult(endpointItem);
 
                             if (endpointsList_Disabled.Contains(endpoint.Name))
                             {
@@ -830,9 +773,9 @@ namespace EndpointChecker
                                             httpWebRequest = PrepareHTTPWebRequest(
                                                 endpoint,
                                                 endpointURI,
-                                                httpRequestTimeout,
-                                                autoRedirect_Enable,
-                                                removeURLParameters);
+                                                checkOptions.HttpRequestTimeout,
+                                                checkOptions.AllowAutoRedirect,
+                                                checkOptions.RemoveUrlParameters);
 
                                             try
                                             {
@@ -840,7 +783,7 @@ namespace EndpointChecker
                                                 httpWebResponse = GetHTTPWebResponse(httpWebRequest, 3);
 
                                                 // HANDLE POSSIBLE REDIRECT [3xx]
-                                                if (autoRedirect_Enable && ((int)httpWebResponse.StatusCode).ToString().StartsWith("3"))
+                                                if (checkOptions.AllowAutoRedirect && ((int)httpWebResponse.StatusCode).ToString().StartsWith("3"))
                                                 {
                                                     throw new WebException(
                                                         "HTTP Response Code: " + (int)httpWebResponse.StatusCode,
@@ -852,7 +795,7 @@ namespace EndpointChecker
                                             catch (WebException wEX)
                                             {
                                                 // IF RESULT CODE IS '3xx', DO A SECOND CALL ON 'LOCATION'
-                                                if (autoRedirect_Enable &&
+                                                if (checkOptions.AllowAutoRedirect &&
                                                     wEX.Response is HttpWebResponse _httpWebResponse &&
                                                     ((int)_httpWebResponse.StatusCode).ToString().StartsWith("3") &&
                                                     _httpWebResponse.Headers.AllKeys.Contains("Location") &&
@@ -871,9 +814,9 @@ namespace EndpointChecker
                                                     HttpWebRequest httpWebRequest_Redirected = PrepareHTTPWebRequest(
                                                         endpoint,
                                                         new Uri(locationHeaderValue),
-                                                        httpRequestTimeout,
-                                                        autoRedirect_Enable,
-                                                        removeURLParameters,
+                                                        checkOptions.HttpRequestTimeout,
+                                                        checkOptions.AllowAutoRedirect,
+                                                        checkOptions.RemoveUrlParameters,
                                                         _httpWebResponse.Cookies);
 
                                                     autoRedirect_Followed = true;
@@ -920,7 +863,7 @@ namespace EndpointChecker
                                             }
 
                                             // GET AUTO REDIRECTS COUNT
-                                            if (autoRedirect_Enable)
+                                            if (checkOptions.AllowAutoRedirect)
                                             {
                                                 FieldInfo fieldInfo = httpWebRequest.GetType().GetField("_AutoRedirects", BindingFlags.NonPublic | BindingFlags.Instance);
                                                 // _AutoRedirects was removed in .NET 10; guard against null fieldInfo
@@ -973,7 +916,7 @@ namespace EndpointChecker
                                             // TRY TO GET HEADER ENCODING FROM RESPONSE HEADER
                                             endpoint.HTTPencoding = GetEncoding(httpWebResponse.ContentType);
 
-                                            if (saveResponse || resolvePageMetaInfo)
+                                            if (checkOptions.SaveResponse || checkOptions.ResolvePageMetaInfo)
                                             {
                                                 // GET RESPONSE STREAM
                                                 using (BinaryReader httpWebResponseBinaryReader = new BinaryReader(httpWebResponse.GetResponseStream()))
@@ -996,7 +939,7 @@ namespace EndpointChecker
                                                     contentLength = httpWebResponseMemoryStream.Length;
                                                     GetWebResponseContentLengthString(endpoint, contentLength);
 
-                                                    if (saveResponse &&
+                                                    if (checkOptions.SaveResponse &&
                                                         !string.IsNullOrEmpty(endpoint.HTTPcontentType) &&
                                                         CheckWebResponseContentLength(endpoint, httpWebResponse, contentLength))
                                                     {
@@ -1014,10 +957,10 @@ namespace EndpointChecker
                                                     if (endpoint.HTTPcontentType == "text/html")
                                                     {
                                                         // GET HTML METADATA
-                                                        if (resolvePageMetaInfo)
+                                                        if (checkOptions.ResolvePageMetaInfo)
                                                         {
                                                             // READ RESPONSE STREAM [HTTP HEADER ENCODING] AND GET HTML META INFO
-                                                            ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTTPencoding), endpoint, responseURI, resolvePageLinks);
+                                                            ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTTPencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
 
                                                             // IF ENCODING NOT PRESENT IN HTTP HEADER, READ AGAIN WITH ENCODING FROM HTML META
                                                             if (endpoint.HTTPencoding == null)
@@ -1026,7 +969,7 @@ namespace EndpointChecker
                                                                 if (endpoint.HTMLencoding != null)
                                                                 {
                                                                     // READ RESPONSE STREAM [HML META ENCODING] AND GET HTML META INFO
-                                                                    ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTMLencoding), endpoint, responseURI, resolvePageLinks);
+                                                                    ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTMLencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
                                                                 }
                                                                 else
                                                                 {
@@ -1203,8 +1146,8 @@ namespace EndpointChecker
                                             // CREATE REQUEST
                                             ftpWebRequest = (FtpWebRequest)WebRequest.Create(endpointURI.OriginalString);
                                             ftpWebRequest.Method = WebRequestMethods.Ftp.PrintWorkingDirectory;
-                                            ftpWebRequest.Timeout = ftpRequestTimeout;
-                                            ftpWebRequest.ReadWriteTimeout = ftpRequestTimeout;
+                                            ftpWebRequest.Timeout = checkOptions.FtpRequestTimeout;
+                                            ftpWebRequest.ReadWriteTimeout = checkOptions.FtpRequestTimeout;
                                             ftpWebRequest.UsePassive = false;
                                             ftpWebRequest.UseBinary = false;
                                             ftpWebRequest.KeepAlive = false;
@@ -1302,7 +1245,7 @@ namespace EndpointChecker
                                     }
 
                                     if (!BW_GetStatus.CancellationPending &&
-                                        resolveIPAddresses)
+                                        checkOptions.ResolveIpAddresses)
                                     {
                                         // RESOLVE IP ADDRESS(ES)
                                         try
@@ -1325,7 +1268,7 @@ namespace EndpointChecker
                                     }
 
                                     if (!BW_GetStatus.CancellationPending &&
-                                        resolveNetworkShares)
+                                        checkOptions.ResolveNetworkShares)
                                     {
                                         // RESOLVE NETWORK SHARES
                                         try
@@ -1346,7 +1289,7 @@ namespace EndpointChecker
                                     }
 
                                     if (!BW_GetStatus.CancellationPending &&
-                                        resolveDNSNames)
+                                        checkOptions.ResolveDnsNames)
                                     {
                                         // RESOLVE DNS NAME(S)
                                         foreach (string _IP_Address in endpointIPAddressesStringList)
@@ -1364,7 +1307,7 @@ namespace EndpointChecker
                                     }
 
                                     if (!BW_GetStatus.CancellationPending &&
-                                        resolveMACAddresses)
+                                        checkOptions.ResolveMacAddresses)
                                     {
                                         foreach (string _IP_Address in endpointIPAddressesStringList)
                                         {
@@ -1390,7 +1333,7 @@ namespace EndpointChecker
                                     }
 
                                     if (!BW_GetStatus.CancellationPending &&
-                                        testPing)
+                                        checkOptions.TestPing)
                                     {
                                         if (validationMethod == ValidationMethod.Ping)
                                         {
@@ -1400,7 +1343,7 @@ namespace EndpointChecker
                                         // TEST PING
                                         try
                                         {
-                                            string pingRoundtripTime = GetPingTime(responseURI.Host, pingTimeout, 1);
+                                            string pingRoundtripTime = GetPingTime(responseURI.Host, checkOptions.PingTimeout, 1);
 
                                             if (!string.IsNullOrEmpty(pingRoundtripTime))
                                             {
@@ -1470,40 +1413,7 @@ namespace EndpointChecker
                                 // crash the whole scan — mark this endpoint as error and continue.
                                 try
                                 {
-                                    updatedEndpointsList.Add(new EndpointDefinition
-                                    {
-                                        Name             = endpointItem.Name,
-                                        Address          = endpointItem.Address,
-                                        ResponseAddress  = endpointItem.ResponseAddress ?? endpointItem.Address,
-                                        Protocol         = endpointItem.Protocol ?? status_NotAvailable,
-                                        Port             = endpointItem.Port ?? status_NotAvailable,
-                                        ResponseCode     = status_Error,
-                                        ResponseMessage  = lambdaEx.GetType().Name + " -> " + lambdaEx.Message,
-                                        ResponseTime     = status_NotAvailable,
-                                        LastSeenOnline   = endpointItem.LastSeenOnline ?? status_NotAvailable,
-                                        PingRoundtripTime= status_NotAvailable,
-                                        ServerID         = status_NotAvailable,
-                                        LoginName        = endpointItem.LoginName ?? status_NotAvailable,
-                                        LoginPass        = endpointItem.LoginPass ?? status_NotAvailable,
-                                        IPAddress        = endpointItem.IPAddress ?? new string[] { status_NotAvailable },
-                                        DNSName          = endpointItem.DNSName ?? new string[] { status_NotAvailable },
-                                        NetworkShare     = endpointItem.NetworkShare ?? new string[] { status_NotAvailable },
-                                        MACAddress       = endpointItem.MACAddress ?? new string[] { status_NotAvailable },
-                                        HTMLMetaInfo     = new PropertyItems { PropertyItem = new List<Property>() },
-                                        HTMLPageLinks    = new PropertyItems { PropertyItem = new List<Property>() },
-                                        HTTPRequestHeaders  = new PropertyItems { PropertyItem = new List<Property>() },
-                                        HTTPResponseHeaders = new PropertyItems { PropertyItem = new List<Property>() },
-                                        SSLCertificateProperties = new PropertyItems { PropertyItem = new List<Property>() },
-                                        HTTPautoRedirects = status_NotAvailable,
-                                        HTTPcontentType   = status_NotAvailable,
-                                        HTTPcontentLength = status_NotAvailable,
-                                        HTTPexpires       = status_NotAvailable,
-                                        HTTPetag          = status_NotAvailable,
-                                        FTPBannerMessage  = status_NotAvailable,
-                                        FTPWelcomeMessage = status_NotAvailable,
-                                        FTPExitMessage    = status_NotAvailable,
-                                        FTPStatusDescription = status_NotAvailable
-                                    });
+                                    updatedEndpointsList.Add(EndpointCheckResultFactory.CreateUnhandledExceptionResult(endpointItem, lambdaEx));
                                 }
                                 catch { /* if even the fallback fails, skip this endpoint */ }
                             }
@@ -1514,7 +1424,7 @@ namespace EndpointChecker
                 DateTime endDT_List = DateTime.Now;
                 int durationTime_List = (int)(endDT_List - startDT_List).TotalSeconds;
 
-                if (autoAdjustRefreshTimer)
+                if (checkOptions.AutoAdjustRefreshTimer)
                 {
                     // ADJUST AUTO REFRESH INTERVAL BY LAST PROGRESS DURATION TIME (+ 1 MINUTE RESERVE]
                     decimal durationTime_List_Minutes = durationTime_List / 60000;
@@ -1542,17 +1452,17 @@ namespace EndpointChecker
                                       startDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
                                       endDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
                                       durationTime_List,
-                                      pingTimeout / 1000,
-                                      httpRequestTimeout / 1000,
-                                      ftpRequestTimeout / 1000,
-                                      FormatBoolToString(autoRedirect_Enable),
-                                      FormatBoolToString(validateSSLCertificate),
-                                      threadsCount.ToString(),
-                                      FormatBoolToString(resolveNetworkShares),
-                                      FormatBoolToString(resolvePageMetaInfo),
-                                      FormatBoolToString(saveResponse),
-                                      FormatBoolToString(testPing),
-                                      FormatBoolToString(resolveDNSNames)
+                                      checkOptions.PingTimeout / 1000,
+                                      checkOptions.HttpRequestTimeout / 1000,
+                                      checkOptions.FtpRequestTimeout / 1000,
+                                      FormatBoolToString(checkOptions.AllowAutoRedirect),
+                                      FormatBoolToString(checkOptions.ValidateSslCertificate),
+                                      checkOptions.ThreadsCount.ToString(),
+                                      FormatBoolToString(checkOptions.ResolveNetworkShares),
+                                      FormatBoolToString(checkOptions.ResolvePageMetaInfo),
+                                      FormatBoolToString(checkOptions.SaveResponse),
+                                      FormatBoolToString(checkOptions.TestPing),
+                                      FormatBoolToString(checkOptions.ResolveDnsNames)
                                       );
             }
             catch (Exception eX)

--- a/src/EndpointCheckOptions.cs
+++ b/src/EndpointCheckOptions.cs
@@ -1,0 +1,129 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal sealed class EndpointCheckOptions
+    {
+        private EndpointCheckOptions(
+            bool allowAutoRedirect,
+            bool validateSslCertificate,
+            bool autoAdjustRefreshTimer,
+            bool resolveNetworkShares,
+            bool resolvePageMetaInfo,
+            bool removeUrlParameters,
+            bool resolvePageLinks,
+            bool saveResponse,
+            bool testPing,
+            bool resolveDnsNames,
+            bool resolveIpAddresses,
+            bool resolveMacAddresses,
+            int threadsCount,
+            int pingTimeout,
+            int httpRequestTimeout,
+            int ftpRequestTimeout)
+        {
+            AllowAutoRedirect = allowAutoRedirect;
+            ValidateSslCertificate = validateSslCertificate;
+            AutoAdjustRefreshTimer = autoAdjustRefreshTimer;
+            ResolveNetworkShares = resolveNetworkShares;
+            ResolvePageMetaInfo = resolvePageMetaInfo;
+            RemoveUrlParameters = removeUrlParameters;
+            ResolvePageLinks = resolvePageLinks;
+            SaveResponse = saveResponse;
+            TestPing = testPing;
+            ResolveDnsNames = resolveDnsNames;
+            ResolveIpAddresses = resolveIpAddresses;
+            ResolveMacAddresses = resolveMacAddresses;
+            ThreadsCount = threadsCount;
+            PingTimeout = pingTimeout;
+            HttpRequestTimeout = httpRequestTimeout;
+            FtpRequestTimeout = ftpRequestTimeout;
+        }
+
+        public bool AllowAutoRedirect { get; }
+        public bool ValidateSslCertificate { get; }
+        public bool AutoAdjustRefreshTimer { get; }
+        public bool ResolveNetworkShares { get; }
+        public bool ResolvePageMetaInfo { get; }
+        public bool RemoveUrlParameters { get; }
+        public bool ResolvePageLinks { get; }
+        public bool SaveResponse { get; }
+        public bool TestPing { get; }
+        public bool ResolveDnsNames { get; }
+        public bool ResolveIpAddresses { get; }
+        public bool ResolveMacAddresses { get; }
+        public int ThreadsCount { get; }
+        public int PingTimeout { get; }
+        public int HttpRequestTimeout { get; }
+        public int FtpRequestTimeout { get; }
+
+        public static EndpointCheckOptions FromUiValues(
+            bool allowAutoRedirect,
+            bool validateSslCertificate,
+            bool autoAdjustRefreshTimer,
+            bool resolveNetworkShares,
+            bool resolvePageMetaInfo,
+            bool removeUrlParameters,
+            bool resolvePageLinks,
+            bool saveResponse,
+            bool testPing,
+            bool resolveDnsNames,
+            bool resolveIpAddresses,
+            bool resolveMacAddresses,
+            int threadsCount,
+            int pingTimeoutSeconds,
+            int httpRequestTimeoutSeconds,
+            int ftpRequestTimeoutSeconds)
+        {
+            return new EndpointCheckOptions(
+                allowAutoRedirect,
+                validateSslCertificate,
+                autoAdjustRefreshTimer,
+                resolveNetworkShares,
+                resolvePageMetaInfo,
+                removeUrlParameters,
+                resolvePageLinks,
+                saveResponse,
+                testPing,
+                resolveDnsNames,
+                resolveIpAddresses,
+                resolveMacAddresses,
+                threadsCount,
+                checked(pingTimeoutSeconds * 1000),
+                checked(httpRequestTimeoutSeconds * 1000),
+                checked(ftpRequestTimeoutSeconds * 1000));
+        }
+
+        public EndpointCheckOptions WithThreadCountAdjustedForEnabledEndpoints(int enabledEndpointsCount)
+        {
+            if (enabledEndpointsCount > 0 &&
+                enabledEndpointsCount < ThreadsCount)
+            {
+                return WithThreadsCount(enabledEndpointsCount);
+            }
+
+            return this;
+        }
+
+        private EndpointCheckOptions WithThreadsCount(int threadsCount)
+        {
+            return new EndpointCheckOptions(
+                AllowAutoRedirect,
+                ValidateSslCertificate,
+                AutoAdjustRefreshTimer,
+                ResolveNetworkShares,
+                ResolvePageMetaInfo,
+                RemoveUrlParameters,
+                ResolvePageLinks,
+                SaveResponse,
+                TestPing,
+                ResolveDnsNames,
+                ResolveIpAddresses,
+                ResolveMacAddresses,
+                threadsCount,
+                PingTimeout,
+                HttpRequestTimeout,
+                FtpRequestTimeout);
+        }
+    }
+}

--- a/src/EndpointCheckResultFactory.cs
+++ b/src/EndpointCheckResultFactory.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace EndpointChecker
+{
+    internal static class EndpointCheckResultFactory
+    {
+        private const string StatusNotAvailable = "N/A";
+        private const string StatusError = "ERROR";
+        private const string ResponseMessageNotCheckedYet = "Not Checked Yet";
+
+        public static EndpointDefinition CreatePendingResult(EndpointDefinition source)
+        {
+            return new EndpointDefinition()
+            {
+                Name = source.Name,
+                Address = source.Address,
+                Protocol = source.Protocol,
+                Port = source.Port,
+                IPAddress = new string[] { StatusNotAvailable },
+                DNSName = new string[] { StatusNotAvailable },
+                ResponseTime = StatusNotAvailable,
+                ResponseCode = StatusNotAvailable,
+                ResponseMessage = ResponseMessageNotCheckedYet,
+                LastSeenOnline = source.LastSeenOnline,
+                PingRoundtripTime = StatusNotAvailable,
+                ServerID = StatusNotAvailable,
+                LoginName = source.LoginName,
+                LoginPass = source.LoginPass,
+                NetworkShare = new string[] { StatusNotAvailable },
+                HTMLMetaInfo = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTTPautoRedirects = StatusNotAvailable,
+                HTTPcontentType = StatusNotAvailable,
+                HTTPencoding = null,
+                HTMLencoding = null,
+                HTMLTitle = StatusNotAvailable,
+                HTMLAuthor = StatusNotAvailable,
+                HTMLDescription = StatusNotAvailable,
+                HTMLContentLanguage = StatusNotAvailable,
+                HTMLThemeColor = Color.Empty,
+                HTMLPageLinks = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTTPcontentLength = StatusNotAvailable,
+                HTTPexpires = StatusNotAvailable,
+                HTTPetag = StatusNotAvailable,
+                HTTPRequestHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
+                HTTPResponseHeaders = new PropertyItems() { PropertyItem = new List<Property>() },
+                MACAddress = new string[] { StatusNotAvailable },
+                FTPBannerMessage = StatusNotAvailable,
+                FTPWelcomeMessage = StatusNotAvailable,
+                FTPExitMessage = StatusNotAvailable,
+                FTPStatusDescription = StatusNotAvailable,
+                SSLCertificateProperties = new PropertyItems() { PropertyItem = new List<Property>() }
+            };
+        }
+
+        public static EndpointDefinition CreateUnhandledExceptionResult(EndpointDefinition source, Exception exception)
+        {
+            return new EndpointDefinition
+            {
+                Name = source.Name,
+                Address = source.Address,
+                ResponseAddress = source.ResponseAddress ?? source.Address,
+                Protocol = source.Protocol ?? StatusNotAvailable,
+                Port = source.Port ?? StatusNotAvailable,
+                ResponseCode = StatusError,
+                ResponseMessage = exception.GetType().Name + " -> " + exception.Message,
+                ResponseTime = StatusNotAvailable,
+                LastSeenOnline = source.LastSeenOnline ?? StatusNotAvailable,
+                PingRoundtripTime = StatusNotAvailable,
+                ServerID = StatusNotAvailable,
+                LoginName = source.LoginName ?? StatusNotAvailable,
+                LoginPass = source.LoginPass ?? StatusNotAvailable,
+                IPAddress = source.IPAddress ?? new string[] { StatusNotAvailable },
+                DNSName = source.DNSName ?? new string[] { StatusNotAvailable },
+                NetworkShare = source.NetworkShare ?? new string[] { StatusNotAvailable },
+                MACAddress = source.MACAddress ?? new string[] { StatusNotAvailable },
+                HTMLMetaInfo = new PropertyItems { PropertyItem = new List<Property>() },
+                HTMLPageLinks = new PropertyItems { PropertyItem = new List<Property>() },
+                HTTPRequestHeaders = new PropertyItems { PropertyItem = new List<Property>() },
+                HTTPResponseHeaders = new PropertyItems { PropertyItem = new List<Property>() },
+                SSLCertificateProperties = new PropertyItems { PropertyItem = new List<Property>() },
+                HTTPautoRedirects = StatusNotAvailable,
+                HTTPcontentType = StatusNotAvailable,
+                HTTPcontentLength = StatusNotAvailable,
+                HTTPexpires = StatusNotAvailable,
+                HTTPetag = StatusNotAvailable,
+                FTPBannerMessage = StatusNotAvailable,
+                FTPWelcomeMessage = StatusNotAvailable,
+                FTPExitMessage = StatusNotAvailable,
+                FTPStatusDescription = StatusNotAvailable
+            };
+        }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
@@ -1,0 +1,165 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal static class EndpointCheckingCoreTestRunner
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            EndpointCheckOptionsTests.Register();
+            EndpointCheckResultFactoryTests.Register();
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        public static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        public static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+
+        public static void AssertArray(string[] expected, string[] actual)
+        {
+            if (expected.Length != actual.Length)
+            {
+                throw new InvalidOperationException("Expected array length <" + expected.Length + "> but was <" + actual.Length + ">.");
+            }
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                AssertEqual(expected[i], actual[i]);
+            }
+        }
+    }
+
+    internal static class EndpointCheckOptionsTests
+    {
+        public static void Register()
+        {
+            Run("UI seconds are converted to millisecond timeouts", UiSecondsAreConvertedToMillisecondTimeouts);
+            Run("Boolean options preserve UI values", BooleanOptionsPreserveUiValues);
+            Run("Thread count is reduced to enabled endpoint count", ThreadCountIsReducedToEnabledEndpointCount);
+            Run("Thread count is unchanged when enabled endpoint count is zero", ThreadCountIsUnchangedWhenEnabledEndpointCountIsZero);
+            Run("Thread count is unchanged when enabled endpoint count is greater", ThreadCountIsUnchangedWhenEnabledEndpointCountIsGreater);
+        }
+
+        private static void UiSecondsAreConvertedToMillisecondTimeouts()
+        {
+            EndpointCheckOptions options = BuildOptions(
+                pingTimeoutSeconds: 3,
+                httpRequestTimeoutSeconds: 30,
+                ftpRequestTimeoutSeconds: 45);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(3000, options.PingTimeout);
+            EndpointCheckingCoreTestRunner.AssertEqual(30000, options.HttpRequestTimeout);
+            EndpointCheckingCoreTestRunner.AssertEqual(45000, options.FtpRequestTimeout);
+        }
+
+        private static void BooleanOptionsPreserveUiValues()
+        {
+            EndpointCheckOptions options = EndpointCheckOptions.FromUiValues(
+                allowAutoRedirect: true,
+                validateSslCertificate: false,
+                autoAdjustRefreshTimer: true,
+                resolveNetworkShares: false,
+                resolvePageMetaInfo: true,
+                removeUrlParameters: false,
+                resolvePageLinks: true,
+                saveResponse: false,
+                testPing: true,
+                resolveDnsNames: false,
+                resolveIpAddresses: true,
+                resolveMacAddresses: false,
+                threadsCount: 7,
+                pingTimeoutSeconds: 1,
+                httpRequestTimeoutSeconds: 2,
+                ftpRequestTimeoutSeconds: 3);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.AllowAutoRedirect);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.ValidateSslCertificate);
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.AutoAdjustRefreshTimer);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.ResolveNetworkShares);
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.ResolvePageMetaInfo);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.RemoveUrlParameters);
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.ResolvePageLinks);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.SaveResponse);
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.TestPing);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.ResolveDnsNames);
+            EndpointCheckingCoreTestRunner.AssertEqual(true, options.ResolveIpAddresses);
+            EndpointCheckingCoreTestRunner.AssertEqual(false, options.ResolveMacAddresses);
+            EndpointCheckingCoreTestRunner.AssertEqual(7, options.ThreadsCount);
+        }
+
+        private static void ThreadCountIsReducedToEnabledEndpointCount()
+        {
+            EndpointCheckOptions options = BuildOptions(threadsCount: 8)
+                .WithThreadCountAdjustedForEnabledEndpoints(3);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(3, options.ThreadsCount);
+        }
+
+        private static void ThreadCountIsUnchangedWhenEnabledEndpointCountIsZero()
+        {
+            EndpointCheckOptions options = BuildOptions(threadsCount: 8)
+                .WithThreadCountAdjustedForEnabledEndpoints(0);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(8, options.ThreadsCount);
+        }
+
+        private static void ThreadCountIsUnchangedWhenEnabledEndpointCountIsGreater()
+        {
+            EndpointCheckOptions options = BuildOptions(threadsCount: 4)
+                .WithThreadCountAdjustedForEnabledEndpoints(8);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(4, options.ThreadsCount);
+        }
+
+        private static EndpointCheckOptions BuildOptions(
+            int threadsCount = 1,
+            int pingTimeoutSeconds = 1,
+            int httpRequestTimeoutSeconds = 1,
+            int ftpRequestTimeoutSeconds = 1)
+        {
+            return EndpointCheckOptions.FromUiValues(
+                allowAutoRedirect: false,
+                validateSslCertificate: false,
+                autoAdjustRefreshTimer: false,
+                resolveNetworkShares: false,
+                resolvePageMetaInfo: false,
+                removeUrlParameters: false,
+                resolvePageLinks: false,
+                saveResponse: false,
+                testPing: false,
+                resolveDnsNames: false,
+                resolveIpAddresses: false,
+                resolveMacAddresses: false,
+                threadsCount: threadsCount,
+                pingTimeoutSeconds: pingTimeoutSeconds,
+                httpRequestTimeoutSeconds: httpRequestTimeoutSeconds,
+                ftpRequestTimeoutSeconds: ftpRequestTimeoutSeconds);
+        }
+
+        private static void Run(string name, Action test) => EndpointCheckingCoreTestRunner.Run(name, test);
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckResultFactoryTests.cs
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckResultFactoryTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+
+namespace EndpointChecker
+{
+    internal static class EndpointCheckResultFactoryTests
+    {
+        public static void Register()
+        {
+            EndpointCheckingCoreTestRunner.Run("Pending check result preserves source identity fields", PendingCheckResultPreservesSourceIdentityFields);
+            EndpointCheckingCoreTestRunner.Run("Pending check result initializes current legacy defaults", PendingCheckResultInitializesCurrentLegacyDefaults);
+            EndpointCheckingCoreTestRunner.Run("Unhandled exception result preserves current error mapping", UnhandledExceptionResultPreservesCurrentErrorMapping);
+        }
+
+        private static void PendingCheckResultPreservesSourceIdentityFields()
+        {
+            EndpointDefinition source = BuildSourceEndpoint();
+            EndpointDefinition result = EndpointCheckResultFactory.CreatePendingResult(source);
+
+            EndpointCheckingCoreTestRunner.AssertEqual("Endpoint", result.Name);
+            EndpointCheckingCoreTestRunner.AssertEqual("http://example.com", result.Address);
+            EndpointCheckingCoreTestRunner.AssertEqual("HTTP", result.Protocol);
+            EndpointCheckingCoreTestRunner.AssertEqual("80", result.Port);
+            EndpointCheckingCoreTestRunner.AssertEqual("2026-08-02 10:15:00", result.LastSeenOnline);
+            EndpointCheckingCoreTestRunner.AssertEqual("user", result.LoginName);
+            EndpointCheckingCoreTestRunner.AssertEqual("pass", result.LoginPass);
+        }
+
+        private static void PendingCheckResultInitializesCurrentLegacyDefaults()
+        {
+            EndpointDefinition result = EndpointCheckResultFactory.CreatePendingResult(BuildSourceEndpoint());
+
+            EndpointCheckingCoreTestRunner.AssertArray(new[] { "N/A" }, result.IPAddress);
+            EndpointCheckingCoreTestRunner.AssertArray(new[] { "N/A" }, result.DNSName);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.ResponseTime);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.ResponseCode);
+            EndpointCheckingCoreTestRunner.AssertEqual("Not Checked Yet", result.ResponseMessage);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.PingRoundtripTime);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.ServerID);
+            EndpointCheckingCoreTestRunner.AssertArray(new[] { "N/A" }, result.NetworkShare);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, result.HTMLMetaInfo.PropertyItem.Count);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTTPautoRedirects);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTTPcontentType);
+            EndpointCheckingCoreTestRunner.AssertEqual(null, result.HTTPencoding);
+            EndpointCheckingCoreTestRunner.AssertEqual(null, result.HTMLencoding);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTMLTitle);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTMLAuthor);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTMLDescription);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTMLContentLanguage);
+            EndpointCheckingCoreTestRunner.AssertEqual(Color.Empty, result.HTMLThemeColor);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, result.HTMLPageLinks.PropertyItem.Count);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTTPcontentLength);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTTPexpires);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.HTTPetag);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, result.HTTPRequestHeaders.PropertyItem.Count);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, result.HTTPResponseHeaders.PropertyItem.Count);
+            EndpointCheckingCoreTestRunner.AssertArray(new[] { "N/A" }, result.MACAddress);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.FTPBannerMessage);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.FTPWelcomeMessage);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.FTPExitMessage);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.FTPStatusDescription);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, result.SSLCertificateProperties.PropertyItem.Count);
+        }
+
+        private static void UnhandledExceptionResultPreservesCurrentErrorMapping()
+        {
+            EndpointDefinition source = BuildSourceEndpoint();
+            EndpointDefinition result = EndpointCheckResultFactory.CreateUnhandledExceptionResult(source, new InvalidOperationException("boom"));
+
+            EndpointCheckingCoreTestRunner.AssertEqual("ERROR", result.ResponseCode);
+            EndpointCheckingCoreTestRunner.AssertEqual("InvalidOperationException -> boom", result.ResponseMessage);
+            EndpointCheckingCoreTestRunner.AssertEqual("http://example.com/response", result.ResponseAddress);
+            EndpointCheckingCoreTestRunner.AssertEqual("N/A", result.ResponseTime);
+            EndpointCheckingCoreTestRunner.AssertEqual("2026-08-02 10:15:00", result.LastSeenOnline);
+        }
+
+        private static EndpointDefinition BuildSourceEndpoint()
+        {
+            return new EndpointDefinition
+            {
+                Name = "Endpoint",
+                Address = "http://example.com",
+                ResponseAddress = "http://example.com/response",
+                Protocol = "HTTP",
+                Port = "80",
+                LoginName = "user",
+                LoginPass = "pass",
+                LastSeenOnline = "2026-08-02 10:15:00",
+                IPAddress = new[] { "192.0.2.10" },
+                DNSName = new[] { "example.com" },
+                NetworkShare = new[] { "Share" },
+                MACAddress = new[] { "00-00-00-00-00-00" }
+            };
+        }
+    }
+
+    public class EndpointDefinition
+    {
+        public string Name { get; set; }
+        public string Protocol { get; set; }
+        public string Port { get; set; }
+        public string Address { get; set; }
+        public string ResponseAddress { get; set; }
+        public string[] IPAddress { get; set; }
+        public string ResponseTime { get; set; }
+        public string ResponseCode { get; set; }
+        public string ResponseMessage { get; set; }
+        public string PingRoundtripTime { get; set; }
+        public string ServerID { get; set; }
+        public string LoginName { get; set; }
+        public string LoginPass { get; set; }
+        public string[] NetworkShare { get; set; }
+        public string[] DNSName { get; set; }
+        public PropertyItems HTMLMetaInfo { get; set; }
+        public string HTTPautoRedirects { get; set; }
+        public string HTTPcontentType { get; set; }
+        public string HTTPcontentLength { get; set; }
+        public string HTTPexpires { get; set; }
+        public string HTTPetag { get; set; }
+        public Encoding HTTPencoding { get; set; }
+        public Encoding HTMLencoding { get; set; }
+        public Encoding HTMLdefaultStreamEncoding { get; set; }
+        public string HTMLTitle { get; set; }
+        public string HTMLAuthor { get; set; }
+        public string HTMLDescription { get; set; }
+        public string HTMLContentLanguage { get; set; }
+        public Color HTMLThemeColor { get; set; }
+        public PropertyItems HTTPRequestHeaders { get; set; }
+        public PropertyItems HTTPResponseHeaders { get; set; }
+        public string[] MACAddress { get; set; }
+        public string FTPBannerMessage { get; set; }
+        public string FTPWelcomeMessage { get; set; }
+        public string FTPExitMessage { get; set; }
+        public string FTPStatusDescription { get; set; }
+        public string LastSeenOnline { get; set; }
+        public PropertyItems SSLCertificateProperties { get; set; }
+        public PropertyItems HTMLPageLinks { get; set; }
+    }
+
+    public class Property
+    {
+        public string ItemName { get; set; }
+        public string ItemValue { get; set; }
+    }
+
+    public class PropertyItems
+    {
+        public List<Property> PropertyItem { get; set; }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointCheckOptions.cs" Link="EndpointCheckOptions.cs" />
+    <Compile Include="..\..\src\EndpointCheckResultFactory.cs" Link="EndpointCheckResultFactory.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Extract EndpointCheckOptions as a snapshot of UI-derived checker settings
- Preserve timeout conversion, thread-count adjustment, and all option values
- Extract pending endpoint check-result initialization and unhandled endpoint exception result mapping
- Add dependency-free characterization tests for the extracted core boundaries
- Update the v3 refactoring programme note for Ticket 1 and Ticket 2

## Preserved behavior
- BackgroundWorker orchestration remains in CheckerMainForm
- HTTP request construction, headers, cookies, auth, redirects, retries, SSL, Cloudflare, timeout, cancellation, FTP, DNS, MAC, ping, export, and UI behavior are unchanged
- Existing N/A, ERROR, Not Checked Yet, and exception response text mapping are preserved

## Verification
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj: passed
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj: passed with expected Uri.EscapeUriString warning
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true: passed with existing warnings