### PR TITLE
Extract HTTP compatibility helpers

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -86,3 +86,46 @@ Verification:
 - `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true`
+
+## Ticket 3: HTTP compatibility boundaries
+
+Status: In progress on `refactor/v3-http-reliability`
+
+Base branch: `v3-main`
+
+Objective:
+
+Reduce the HTTP-checking responsibility inside `CheckerMainForm` by extracting behavior-preserving internal helpers for request construction and Cloudflare response classification.
+
+Scope completed in this ticket:
+
+- Extracted legacy `HttpWebRequest` construction into `EndpointHttpRequestFactory`.
+- Preserved request method, timeout, read/write timeout, redirect setting, keep-alive, cache policy, decompression, HTTP protocol version, maximum automatic redirects, user agent, browser-like headers, credentials, and legacy GDPR cookie injection.
+- Preserved the current non-mutating `removeURLParameters` behavior.
+- Extracted Cloudflare detection into `EndpointHttpResponseClassifier`.
+- Added dependency-free characterization tests for the extracted HTTP compatibility boundaries.
+
+Non-goals:
+
+- No replacement of `HttpWebRequest` with `HttpClient`.
+- No change to redirect-following behavior, retry behavior, SSL certificate handling, response-code mapping, cancellation, disposal, FTP, DNS, MAC, ping, export, persistence, or UI behavior.
+- No public API changes.
+- No dependency additions.
+
+Compatibility notes:
+
+- `WebRequest.Create(endpointURI.AbsoluteUri)` remains intentionally used because endpoint checking behavior is compatibility-sensitive.
+- `AutomaticDecompression` and omitted invalid headers remain preserved from the v3 implementation.
+- `removeURLParameters` intentionally remains non-mutating because the original code called `endpointURI.RemoveQuery()` without assigning the returned URL.
+- Cloudflare classification still treats either `CF-RAY` or a `Server` value containing `cloudflare` as protected.
+
+Tests:
+
+- `tests/HttpCompatibility.Tests` covers request construction and Cloudflare classification.
+
+Verification:
+
+- `dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj`
+- `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`
+- `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
+- `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -1522,90 +1522,14 @@ namespace EndpointChecker
             bool removeURLParameters,
             CookieCollection cookies = null)
         {
-            // REQUEST PARAMETERS
-            string httpWebRequest_Method = WebRequestMethods.Http.Get;
-            Version httpWebRequest_ProtocolVersion = HttpVersion.Version11;
-            RequestCachePolicy httpWebRequest_CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
-            DecompressionMethods httpWebRequest_DecompressionMethods =
-                DecompressionMethods.GZip |
-                DecompressionMethods.Deflate |
-                DecompressionMethods.None;
-
-            if (removeURLParameters)
-            {
-                // REMOVE URL PARAMETERS [IF ANY PRESENT]
-                endpointURI.RemoveQuery();
-            }
-
-            // COOKIE CONTAINER
-            CookieContainer httpWebRequest_CookieContainer = new CookieContainer(300);
-            if (cookies != null)
-            {
-                httpWebRequest_CookieContainer.Add(cookies);
-            }
-
-            // ADD GDPR COOKIES
-            httpWebRequest_CookieContainer.Add(new Cookie("viewed_cookie_policy", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-necessary", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-functional", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-performance", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-analytics", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-advertisement", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-            httpWebRequest_CookieContainer.Add(new Cookie("cookielawinfo-checkbox-others", "yes", endpointURI.AbsolutePath, endpointURI.Host));
-
-            // CREATE REQUEST
-            HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(endpointURI.AbsoluteUri);
-            httpWebRequest.Method = httpWebRequest_Method;
-            httpWebRequest.UserAgent = http_UserAgent;
-            httpWebRequest.Accept = @"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7";
-            httpWebRequest.Timeout = httpRequestTimeout;
-            httpWebRequest.ReadWriteTimeout = httpRequestTimeout;
-            httpWebRequest.AllowAutoRedirect = allowAutoRedirect;
-            httpWebRequest.KeepAlive = true;
-            httpWebRequest.CachePolicy = httpWebRequest_CachePolicy;
-            httpWebRequest.CookieContainer = httpWebRequest_CookieContainer;
-            httpWebRequest.AutomaticDecompression = httpWebRequest_DecompressionMethods;
-            httpWebRequest.ProtocolVersion = httpWebRequest_ProtocolVersion;
-            httpWebRequest.MaximumAutomaticRedirections = 100;
-
-            // CUSTOM HEADERS
-            // Note: "accept-encoding" is intentionally omitted — AutomaticDecompression
-            // manages that header automatically; manually setting it alongside
-            // AutomaticDecompression throws InvalidOperationException on .NET 5+.
-            // HTTP/2 pseudo-headers (:authority/:path/:scheme) are also omitted —
-            // they are not valid HTTP/1.1 headers and HttpWebRequest rejects them on .NET 10.
-            WebHeaderCollection requestHeadersCollection = new WebHeaderCollection
-            {
-                { "accept-language", @"*;*" },
-                { "cache-control", "max-age=0" },
-                { "dnt", "1" },
-                { "upgrade-insecure-requests", "1" },
-
-                { "Sec-Fetch-User", "?1" },
-                { "Sec-Fetch-Site", "none" },
-                { "Sec-Fetch-Mode", "navigate" },
-                { "Sec-Fetch-Dest", "document" },
-                { "Sec-CH-UA-Mobile", "?0" },
-                { "Sec-CH-UA-Platform", "\"Windows\"" }
-
-            };
-            httpWebRequest.Headers.Add(requestHeadersCollection);
-
-            // SET CREDENTIALS
-            httpWebRequest.PreAuthenticate = true;
-            httpWebRequest.AuthenticationLevel = System.Net.Security.AuthenticationLevel.MutualAuthRequested;
-
-            if (endpoint.LoginName != status_NotAvailable &&
-                !string.IsNullOrEmpty(endpoint.LoginName))
-            {
-                // SPECIFIED CREDENTIALS
-                httpWebRequest.Credentials = new NetworkCredential(endpoint.LoginName, endpoint.LoginPass);
-            }
-            else
-            {
-                // CURRENT WINDOWS USER CREDENTIALS
-                httpWebRequest.Credentials = CredentialCache.DefaultCredentials;
-            }
+            HttpWebRequest httpWebRequest = EndpointHttpRequestFactory.Create(
+                endpoint,
+                endpointURI,
+                httpRequestTimeout,
+                allowAutoRedirect,
+                removeURLParameters,
+                http_UserAgent,
+                cookies);
 
             // GET REQUEST HEADERS
             GetHTTPWebHeaders(endpoint.HTTPRequestHeaders.PropertyItem, httpWebRequest.Headers);
@@ -1621,11 +1545,7 @@ namespace EndpointChecker
         {
             if (response == null) return false;
 
-            bool hasCfRay = !string.IsNullOrEmpty(response.Headers["CF-RAY"]);
-            bool hasCfServer = !string.IsNullOrEmpty(response.Server) &&
-                               response.Server.IndexOf("cloudflare", StringComparison.OrdinalIgnoreCase) >= 0;
-
-            return hasCfRay || hasCfServer;
+            return EndpointHttpResponseClassifier.IsCloudflareProtected(response.Headers, response.Server);
         }
 
         public void GetHTTPWebHeaders(

--- a/src/EndpointHttpRequestFactory.cs
+++ b/src/EndpointHttpRequestFactory.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using System.Net.Cache;
+
+namespace EndpointChecker
+{
+    internal static class EndpointHttpRequestFactory
+    {
+        private const string StatusNotAvailable = "N/A";
+
+        public static HttpWebRequest Create(
+            EndpointDefinition endpoint,
+            Uri endpointUri,
+            int httpRequestTimeout,
+            bool allowAutoRedirect,
+            bool removeUrlParameters,
+            string userAgent,
+            CookieCollection cookies = null)
+        {
+            // The legacy Flurl RemoveQuery call did not assign its return value, so this flag is
+            // intentionally non-mutating here to preserve observed request URI behavior.
+            _ = removeUrlParameters;
+
+            CookieContainer cookieContainer = new CookieContainer(300);
+            if (cookies != null)
+            {
+                cookieContainer.Add(cookies);
+            }
+
+            cookieContainer.Add(new Cookie("viewed_cookie_policy", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-necessary", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-functional", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-performance", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-analytics", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-advertisement", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+            cookieContainer.Add(new Cookie("cookielawinfo-checkbox-others", "yes", endpointUri.AbsolutePath, endpointUri.Host));
+
+            HttpWebRequest httpWebRequest = (HttpWebRequest)WebRequest.Create(endpointUri.AbsoluteUri);
+            httpWebRequest.Method = WebRequestMethods.Http.Get;
+            httpWebRequest.UserAgent = userAgent;
+            httpWebRequest.Accept = @"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7";
+            httpWebRequest.Timeout = httpRequestTimeout;
+            httpWebRequest.ReadWriteTimeout = httpRequestTimeout;
+            httpWebRequest.AllowAutoRedirect = allowAutoRedirect;
+            httpWebRequest.KeepAlive = true;
+            httpWebRequest.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
+            httpWebRequest.CookieContainer = cookieContainer;
+            httpWebRequest.AutomaticDecompression =
+                DecompressionMethods.GZip |
+                DecompressionMethods.Deflate |
+                DecompressionMethods.None;
+            httpWebRequest.ProtocolVersion = HttpVersion.Version11;
+            httpWebRequest.MaximumAutomaticRedirections = 100;
+
+            WebHeaderCollection requestHeadersCollection = new WebHeaderCollection
+            {
+                { "accept-language", @"*;*" },
+                { "cache-control", "max-age=0" },
+                { "dnt", "1" },
+                { "upgrade-insecure-requests", "1" },
+                { "Sec-Fetch-User", "?1" },
+                { "Sec-Fetch-Site", "none" },
+                { "Sec-Fetch-Mode", "navigate" },
+                { "Sec-Fetch-Dest", "document" },
+                { "Sec-CH-UA-Mobile", "?0" },
+                { "Sec-CH-UA-Platform", "\"Windows\"" }
+            };
+            httpWebRequest.Headers.Add(requestHeadersCollection);
+
+            httpWebRequest.PreAuthenticate = true;
+            httpWebRequest.AuthenticationLevel = System.Net.Security.AuthenticationLevel.MutualAuthRequested;
+
+            if (endpoint.LoginName != StatusNotAvailable &&
+                !string.IsNullOrEmpty(endpoint.LoginName))
+            {
+                httpWebRequest.Credentials = new NetworkCredential(endpoint.LoginName, endpoint.LoginPass);
+            }
+            else
+            {
+                httpWebRequest.Credentials = CredentialCache.DefaultCredentials;
+            }
+
+            return httpWebRequest;
+        }
+    }
+}

--- a/src/EndpointHttpResponseClassifier.cs
+++ b/src/EndpointHttpResponseClassifier.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Net;
+
+namespace EndpointChecker
+{
+    internal static class EndpointHttpResponseClassifier
+    {
+        public static bool IsCloudflareProtected(WebHeaderCollection headers, string server)
+        {
+            bool hasCfRay = headers != null && !string.IsNullOrEmpty(headers["CF-RAY"]);
+            bool hasCfServer = !string.IsNullOrEmpty(server) &&
+                               server.IndexOf("cloudflare", StringComparison.OrdinalIgnoreCase) >= 0;
+
+            return hasCfRay || hasCfServer;
+        }
+    }
+}

--- a/tests/HttpCompatibility.Tests/EndpointHttpRequestFactoryTests.cs
+++ b/tests/HttpCompatibility.Tests/EndpointHttpRequestFactoryTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Net;
+
+namespace EndpointChecker
+{
+    internal static class EndpointHttpRequestFactoryTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("Factory preserves request method headers and browser-like settings", FactoryPreservesRequestMethodHeadersAndBrowserLikeSettings);
+            Run("Factory preserves timeout and redirect settings", FactoryPreservesTimeoutAndRedirectSettings);
+            Run("Factory preserves default credential behavior", FactoryPreservesDefaultCredentialBehavior);
+            Run("Factory preserves specified credential behavior", FactoryPreservesSpecifiedCredentialBehavior);
+            Run("Factory preserves legacy GDPR cookie injection", FactoryPreservesLegacyGdprCookieInjection);
+            Run("Remove URL parameters flag remains non-mutating", RemoveUrlParametersFlagRemainsNonMutating);
+            Run("Cloudflare classifier preserves CF-RAY detection", CloudflareClassifierPreservesCfRayDetection);
+            Run("Cloudflare classifier preserves server detection", CloudflareClassifierPreservesServerDetection);
+            Run("Cloudflare classifier ignores unrelated responses", CloudflareClassifierIgnoresUnrelatedResponses);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void FactoryPreservesRequestMethodHeadersAndBrowserLikeSettings()
+        {
+            HttpWebRequest request = CreateRequest();
+
+            AssertEqual(WebRequestMethods.Http.Get, request.Method);
+            AssertEqual("EndpointCheckerTest/1.0", request.UserAgent);
+            AssertEqual(@"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7", request.Accept);
+            AssertEqual(HttpVersion.Version11, request.ProtocolVersion);
+            AssertEqual(true, request.KeepAlive);
+            AssertEqual(100, request.MaximumAutomaticRedirections);
+            AssertEqual(DecompressionMethods.GZip | DecompressionMethods.Deflate, request.AutomaticDecompression);
+            AssertEqual(@"*;*", request.Headers["accept-language"]);
+            AssertEqual("max-age=0", request.Headers["cache-control"]);
+            AssertEqual("1", request.Headers["dnt"]);
+            AssertEqual("1", request.Headers["upgrade-insecure-requests"]);
+            AssertEqual("?1", request.Headers["Sec-Fetch-User"]);
+            AssertEqual("none", request.Headers["Sec-Fetch-Site"]);
+            AssertEqual("navigate", request.Headers["Sec-Fetch-Mode"]);
+            AssertEqual("document", request.Headers["Sec-Fetch-Dest"]);
+            AssertEqual("?0", request.Headers["Sec-CH-UA-Mobile"]);
+            AssertEqual("\"Windows\"", request.Headers["Sec-CH-UA-Platform"]);
+        }
+
+        private static void FactoryPreservesTimeoutAndRedirectSettings()
+        {
+            HttpWebRequest request = CreateRequest(timeout: 12345, allowAutoRedirect: false);
+
+            AssertEqual(12345, request.Timeout);
+            AssertEqual(12345, request.ReadWriteTimeout);
+            AssertEqual(false, request.AllowAutoRedirect);
+        }
+
+        private static void FactoryPreservesDefaultCredentialBehavior()
+        {
+            HttpWebRequest request = EndpointHttpRequestFactory.Create(
+                new EndpointDefinition { LoginName = "N/A", LoginPass = "N/A" },
+                new Uri("http://example.com/path"),
+                1000,
+                true,
+                false,
+                "EndpointCheckerTest/1.0");
+
+            AssertEqual(CredentialCache.DefaultCredentials, request.Credentials);
+            AssertEqual(true, request.PreAuthenticate);
+            AssertEqual(System.Net.Security.AuthenticationLevel.MutualAuthRequested, request.AuthenticationLevel);
+        }
+
+        private static void FactoryPreservesSpecifiedCredentialBehavior()
+        {
+            HttpWebRequest request = EndpointHttpRequestFactory.Create(
+                new EndpointDefinition { LoginName = "user", LoginPass = "pass" },
+                new Uri("http://example.com/path"),
+                1000,
+                true,
+                false,
+                "EndpointCheckerTest/1.0");
+
+            NetworkCredential credential = request.Credentials.GetCredential(new Uri("http://example.com/path"), "Basic");
+
+            AssertEqual("user", credential.UserName);
+            AssertEqual("pass", credential.Password);
+        }
+
+        private static void FactoryPreservesLegacyGdprCookieInjection()
+        {
+            Uri uri = new Uri("http://example.com/path");
+            HttpWebRequest request = CreateRequest(uri: uri);
+            CookieCollection cookies = request.CookieContainer.GetCookies(uri);
+
+            AssertEqual("yes", cookies["viewed_cookie_policy"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-necessary"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-functional"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-performance"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-analytics"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-advertisement"].Value);
+            AssertEqual("yes", cookies["cookielawinfo-checkbox-others"].Value);
+        }
+
+        private static void RemoveUrlParametersFlagRemainsNonMutating()
+        {
+            HttpWebRequest request = CreateRequest(uri: new Uri("http://example.com/path?a=1"), removeUrlParameters: true);
+
+            AssertEqual("http://example.com/path?a=1", request.RequestUri.AbsoluteUri);
+        }
+
+        private static HttpWebRequest CreateRequest(
+            Uri uri = null,
+            int timeout = 1000,
+            bool allowAutoRedirect = true,
+            bool removeUrlParameters = false)
+        {
+            return EndpointHttpRequestFactory.Create(
+                new EndpointDefinition { LoginName = "N/A", LoginPass = "N/A" },
+                uri ?? new Uri("http://example.com/path"),
+                timeout,
+                allowAutoRedirect,
+                removeUrlParameters,
+                "EndpointCheckerTest/1.0");
+        }
+
+        private static void CloudflareClassifierPreservesCfRayDetection()
+        {
+            WebHeaderCollection headers = new WebHeaderCollection();
+            headers["CF-RAY"] = "abc123";
+
+            AssertEqual(true, EndpointHttpResponseClassifier.IsCloudflareProtected(headers, null));
+        }
+
+        private static void CloudflareClassifierPreservesServerDetection()
+        {
+            AssertEqual(true, EndpointHttpResponseClassifier.IsCloudflareProtected(new WebHeaderCollection(), "cloudflare"));
+            AssertEqual(true, EndpointHttpResponseClassifier.IsCloudflareProtected(new WebHeaderCollection(), "CloudFlare"));
+        }
+
+        private static void CloudflareClassifierIgnoresUnrelatedResponses()
+        {
+            AssertEqual(false, EndpointHttpResponseClassifier.IsCloudflareProtected(null, null));
+            AssertEqual(false, EndpointHttpResponseClassifier.IsCloudflareProtected(new WebHeaderCollection(), "nginx"));
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+
+    public class EndpointDefinition
+    {
+        public string LoginName { get; set; }
+        public string LoginPass { get; set; }
+    }
+}

--- a/tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
+++ b/tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointHttpRequestFactory.cs" Link="EndpointHttpRequestFactory.cs" />
+    <Compile Include="..\..\src\EndpointHttpResponseClassifier.cs" Link="EndpointHttpResponseClassifier.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- extract legacy HttpWebRequest construction into an internal compatibility factory
- extract Cloudflare response classification into a testable helper
- add dependency-free characterization tests for request settings, credentials, cookies, removeURLParameters behavior, and Cloudflare detection

## Verification
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q

Note: app build still emits the existing NU1900/SYSLIB/CA1416 warnings; there are 0 errors.