### PR TITLE
Extract export option snapshot

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -48,7 +48,7 @@ Verification:
 
 ## Ticket 2: Endpoint checking core extraction
 
-Status: In progress on `refactor/v3-endpoint-checking-core`
+Status: Merged to `v3-main` via PR #45
 
 Base branch: `v3-main`
 
@@ -89,7 +89,7 @@ Verification:
 
 ## Ticket 3: HTTP compatibility boundaries
 
-Status: In progress on `refactor/v3-http-reliability`
+Status: Merged to `v3-main` via PR #46
 
 Base branch: `v3-main`
 
@@ -125,6 +125,42 @@ Tests:
 
 Verification:
 
+- `dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj`
+- `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`
+- `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
+- `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q`
+
+## Ticket 4: Export options snapshot
+
+Status: In progress on `refactor/v3-export-and-ui-mapping`
+
+Base branch: `v3-main`
+
+Objective:
+
+Reduce direct WinForms control coupling inside endpoint-status export generation by extracting a small immutable snapshot of selected export formats.
+
+Scope completed in this ticket:
+
+- Extracted `EndpointExportOptions` from the four export checkbox values.
+- Snapshotted export choices once at the `EndpointsStatusExport` boundary.
+- Replaced repeated direct checkbox reads inside export generation with the snapshot.
+- Added dependency-free characterization tests for the export-options snapshot.
+
+Non-goals:
+
+- No JSON, XML, HTML, or XLSX output format changes.
+- No change to file names, file-lock behavior, worksheet shape, column order, hidden columns, colors, formatting, or export error handling.
+- No configuration load/save behavior changes.
+- No UI redesign.
+
+Tests:
+
+- `tests/ExportOptions.Tests` covers the export-options snapshot.
+
+Verification:
+
+- `dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj`
 - `dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj`
 - `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -2899,6 +2899,12 @@ namespace EndpointChecker
                                           string dnsLookupOnHost
             )
         {
+            EndpointExportOptions exportOptions = EndpointExportOptions.Create(
+                cb_ExportEndpointsStatus_JSON.Checked,
+                cb_ExportEndpointsStatus_XML.Checked,
+                cb_ExportEndpointsStatus_XLSX.Checked,
+                cb_ExportEndpointsStatus_HTML.Checked);
+
             // ERROR LIST
             List<string> errorsList = new List<string>();
 
@@ -2916,13 +2922,12 @@ namespace EndpointChecker
 
             if (exportList.Count > 0)
             {
-                if (cb_ExportEndpointsStatus_JSON.Checked ||
-                    cb_ExportEndpointsStatus_XML.Checked)
+                if (exportOptions.StructuredText)
                 {
                     // SERIALIZE ENDPOINTS LIST TO JSON
                     string jsonString = JsonConvert.SerializeObject(exportList, Newtonsoft.Json.Formatting.Indented);
 
-                    if (cb_ExportEndpointsStatus_JSON.Checked)
+                    if (exportOptions.Json)
                     {
                         // JSON EXPORT
                         // ===========
@@ -2945,7 +2950,7 @@ namespace EndpointChecker
                         }
                     }
 
-                    if (cb_ExportEndpointsStatus_XML.Checked)
+                    if (exportOptions.Xml)
                     {
                         // XML EXPORT
                         // ==========
@@ -2969,7 +2974,7 @@ namespace EndpointChecker
                     }
                 }
 
-                if (cb_ExportEndpointsStatus_XLSX.Checked)
+                if (exportOptions.Xlsx)
                 {
                     // XLSX EXPORT
                     // ===========
@@ -3256,7 +3261,7 @@ namespace EndpointChecker
                                 ex.Message);
                         }
 
-                        if (cb_ExportEndpointsStatus_HTML.Checked)
+                        if (exportOptions.Html)
                         {
                             // HTML EXPORT
                             // ===========
@@ -3271,7 +3276,7 @@ namespace EndpointChecker
                             // SET WHITE BACKGROUND FOR UNUSED CELLS [CREATE SEPARATE CLASS FOR IT]
                             summaryWorkSheet["A09"].Style.Color = Color.White;
 
-                            if (cb_ExportEndpointsStatus_JSON.Checked)
+                            if (exportOptions.Json)
                             {
                                 // ADD 'JSON' HYPERLINK PLACEHOLDER TO 'SUMMARY' PAGE           
                                 RichText jsonPageHyperlink = summaryWorkSheet["A10"].RichText;
@@ -3281,7 +3286,7 @@ namespace EndpointChecker
                                 summaryWorkSheet["A10"].Style.HorizontalAlignment = HorizontalAlignType.Center;
                             }
 
-                            if (cb_ExportEndpointsStatus_XML.Checked)
+                            if (exportOptions.Xml)
                             {
                                 // ADD 'XML' HYPERLINK PLACEHOLDER TO 'SUMMARY' PAGE           
                                 RichText xmlPageHyperlink = summaryWorkSheet["A11"].RichText;

--- a/src/EndpointExportOptions.cs
+++ b/src/EndpointExportOptions.cs
@@ -1,0 +1,28 @@
+namespace EndpointChecker
+{
+    internal sealed class EndpointExportOptions
+    {
+        private EndpointExportOptions(bool json, bool xml, bool xlsx, bool html)
+        {
+            Json = json;
+            Xml = xml;
+            Xlsx = xlsx;
+            Html = html;
+        }
+
+        public bool Json { get; }
+
+        public bool Xml { get; }
+
+        public bool Xlsx { get; }
+
+        public bool Html { get; }
+
+        public bool StructuredText => Json || Xml;
+
+        public static EndpointExportOptions Create(bool json, bool xml, bool xlsx, bool html)
+        {
+            return new EndpointExportOptions(json, xml, xlsx, html);
+        }
+    }
+}

--- a/tests/ExportOptions.Tests/EndpointExportOptionsTests.cs
+++ b/tests/ExportOptions.Tests/EndpointExportOptionsTests.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal static class EndpointExportOptionsTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("Snapshot preserves selected export switches", SnapshotPreservesSelectedExportSwitches);
+            Run("Structured text is enabled for JSON", StructuredTextIsEnabledForJson);
+            Run("Structured text is enabled for XML", StructuredTextIsEnabledForXml);
+            Run("Structured text is disabled without JSON or XML", StructuredTextIsDisabledWithoutJsonOrXml);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void SnapshotPreservesSelectedExportSwitches()
+        {
+            EndpointExportOptions options = EndpointExportOptions.Create(true, false, true, false);
+
+            AssertEqual(true, options.Json);
+            AssertEqual(false, options.Xml);
+            AssertEqual(true, options.Xlsx);
+            AssertEqual(false, options.Html);
+        }
+
+        private static void StructuredTextIsEnabledForJson()
+        {
+            EndpointExportOptions options = EndpointExportOptions.Create(true, false, false, false);
+
+            AssertEqual(true, options.StructuredText);
+        }
+
+        private static void StructuredTextIsEnabledForXml()
+        {
+            EndpointExportOptions options = EndpointExportOptions.Create(false, true, false, false);
+
+            AssertEqual(true, options.StructuredText);
+        }
+
+        private static void StructuredTextIsDisabledWithoutJsonOrXml()
+        {
+            EndpointExportOptions options = EndpointExportOptions.Create(false, false, true, true);
+
+            AssertEqual(false, options.StructuredText);
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+}

--- a/tests/ExportOptions.Tests/ExportOptions.Tests.csproj
+++ b/tests/ExportOptions.Tests/ExportOptions.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointExportOptions.cs" Link="EndpointExportOptions.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an internal EndpointExportOptions snapshot for export format switches
- snapshot export checkbox state once at the EndpointsStatusExport boundary
- use the snapshot through JSON/XML/XLSX/HTML export branching
- add dependency-free characterization tests for the snapshot behavior

## Verification
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q

Note: app build still emits the existing NU1900/SYSLIB/CA1416 warnings; there are 0 errors.