### PR TITLE
Extract export run summary

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -130,9 +130,9 @@ Verification:
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q`
 
-## Ticket 4: Export options snapshot
+## Ticket 4: Export options and run-summary snapshots
 
-Status: In progress on `refactor/v3-export-and-ui-mapping`
+Status: In progress on `refactor/v3-export-run-summary`
 
 Base branch: `v3-main`
 
@@ -146,6 +146,9 @@ Scope completed in this ticket:
 - Snapshotted export choices once at the `EndpointsStatusExport` boundary.
 - Replaced repeated direct checkbox reads inside export generation with the snapshot.
 - Added dependency-free characterization tests for the export-options snapshot.
+- Extracted `EndpointExportRunSummary` for the check/run metadata written to the export summary worksheet.
+- Kept the existing public `EndpointsStatusExport(...)` signature as a wrapper and moved the internal writer path to the summary snapshot.
+- Added dependency-free characterization tests for the export run-summary snapshot.
 
 Non-goals:
 
@@ -157,9 +160,11 @@ Non-goals:
 Tests:
 
 - `tests/ExportOptions.Tests` covers the export-options snapshot.
+- `tests/ExportRunSummary.Tests` covers the export run-summary snapshot.
 
 Verification:
 
+- `dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj`
 - `dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj`
 - `dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj`
 - `dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -1447,23 +1447,24 @@ namespace EndpointChecker
                 // SORT ENDPOINTS LIST BY ENDPOINT NAME
                 endpointsList.Sort((s, t) => string.Compare(s.Name, t.Name));
 
+                EndpointExportRunSummary exportRunSummary = EndpointExportRunSummary.Create(
+                    startDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
+                    endDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
+                    durationTime_List,
+                    checkOptions.PingTimeout / 1000,
+                    checkOptions.HttpRequestTimeout / 1000,
+                    checkOptions.FtpRequestTimeout / 1000,
+                    FormatBoolToString(checkOptions.AllowAutoRedirect),
+                    FormatBoolToString(checkOptions.ValidateSslCertificate),
+                    checkOptions.ThreadsCount.ToString(),
+                    FormatBoolToString(checkOptions.ResolveNetworkShares),
+                    FormatBoolToString(checkOptions.ResolvePageMetaInfo),
+                    FormatBoolToString(checkOptions.SaveResponse),
+                    FormatBoolToString(checkOptions.TestPing),
+                    FormatBoolToString(checkOptions.ResolveDnsNames));
+
                 // EXPORT UPDATED LIST
-                EndpointsStatusExport(
-                                      startDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
-                                      endDT_List.ToString("dd.MM.yyyy HH:mm:ss"),
-                                      durationTime_List,
-                                      checkOptions.PingTimeout / 1000,
-                                      checkOptions.HttpRequestTimeout / 1000,
-                                      checkOptions.FtpRequestTimeout / 1000,
-                                      FormatBoolToString(checkOptions.AllowAutoRedirect),
-                                      FormatBoolToString(checkOptions.ValidateSslCertificate),
-                                      checkOptions.ThreadsCount.ToString(),
-                                      FormatBoolToString(checkOptions.ResolveNetworkShares),
-                                      FormatBoolToString(checkOptions.ResolvePageMetaInfo),
-                                      FormatBoolToString(checkOptions.SaveResponse),
-                                      FormatBoolToString(checkOptions.TestPing),
-                                      FormatBoolToString(checkOptions.ResolveDnsNames)
-                                      );
+                EndpointsStatusExport(exportRunSummary);
             }
             catch (Exception eX)
             {
@@ -2899,6 +2900,25 @@ namespace EndpointChecker
                                           string dnsLookupOnHost
             )
         {
+            EndpointsStatusExport(EndpointExportRunSummary.Create(
+                startDT,
+                endDT,
+                durationSeconds,
+                pingTimeout,
+                httpRequestTimeout,
+                ftpRequestTimeout,
+                httpAutoRedirection,
+                sslCertificateValidation,
+                threadsCount,
+                resolveNetworkShares,
+                resolvePageMetaInfo,
+                saveResponse,
+                pingHost,
+                dnsLookupOnHost));
+        }
+
+        private void EndpointsStatusExport(EndpointExportRunSummary summary)
+        {
             EndpointExportOptions exportOptions = EndpointExportOptions.Create(
                 cb_ExportEndpointsStatus_JSON.Checked,
                 cb_ExportEndpointsStatus_XML.Checked,
@@ -3146,37 +3166,37 @@ namespace EndpointChecker
                         endpointsStatusExport_Summary_WorkSheet.Cell("B7").SetValue(Environment.MachineName);
 
                         endpointsStatusExport_Summary_WorkSheet.Cell("D1").SetValue("Check Started");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E1").SetValue(startDT);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E1").SetValue(summary.StartDateTime);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D2").SetValue("Check Ended");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E2").SetValue(endDT);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E2").SetValue(summary.EndDateTime);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D3").SetValue("Check Duration");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E3").SetValue(durationSeconds + " " + GetFormattedValueCountString(durationSeconds, "second"));
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E3").SetValue(summary.DurationSeconds + " " + GetFormattedValueCountString(summary.DurationSeconds, "second"));
                         endpointsStatusExport_Summary_WorkSheet.Cell("D4").SetValue("HTTP Endpoints Count");
                         endpointsStatusExport_Summary_WorkSheet.Cell("E4").SetValue((httpWorkSheetLineNumber - 2).ToString());
                         endpointsStatusExport_Summary_WorkSheet.Cell("D5").SetValue("FTP Endpoints Count");
                         endpointsStatusExport_Summary_WorkSheet.Cell("E5").SetValue((ftpWorkSheetLineNumber - 2).ToString());
                         endpointsStatusExport_Summary_WorkSheet.Cell("D6").SetValue("Parallel Threads Count");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E6").SetValue(threadsCount);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E6").SetValue(summary.ThreadsCount);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D7").SetValue("Ping Timeout");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E7").SetValue(pingTimeout + " " + GetFormattedValueCountString(pingTimeout, "second"));
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E7").SetValue(summary.PingTimeoutSeconds + " " + GetFormattedValueCountString(summary.PingTimeoutSeconds, "second"));
                         endpointsStatusExport_Summary_WorkSheet.Cell("D8").SetValue("HTTP Request Timeout");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E8").SetValue(httpRequestTimeout + " " + GetFormattedValueCountString(httpRequestTimeout, "second"));
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E8").SetValue(summary.HttpRequestTimeoutSeconds + " " + GetFormattedValueCountString(summary.HttpRequestTimeoutSeconds, "second"));
                         endpointsStatusExport_Summary_WorkSheet.Cell("D9").SetValue("FTP Request Timeout");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E9").SetValue(ftpRequestTimeout + " " + GetFormattedValueCountString(ftpRequestTimeout, "second"));
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E9").SetValue(summary.FtpRequestTimeoutSeconds + " " + GetFormattedValueCountString(summary.FtpRequestTimeoutSeconds, "second"));
                         endpointsStatusExport_Summary_WorkSheet.Cell("D10").SetValue("Server Certificate Validation [HTTPS]");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E10").SetValue(sslCertificateValidation);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E10").SetValue(summary.SslCertificateValidation);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D11").SetValue("Auto Redirection [HTTP]");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E11").SetValue(httpAutoRedirection);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E11").SetValue(summary.HttpAutoRedirection);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D12").SetValue("Resolve Network Shares");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E12").SetValue(resolveNetworkShares);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E12").SetValue(summary.ResolveNetworkShares);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D13").SetValue("Resolve Page Meta Info [HTTP/HTML]");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E13").SetValue(resolvePageMetaInfo);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E13").SetValue(summary.ResolvePageMetaInfo);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D14").SetValue("Save Response [HTTP]");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E14").SetValue(saveResponse);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E14").SetValue(summary.SaveResponse);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D15").SetValue("Ping Host");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E15").SetValue(pingHost);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E15").SetValue(summary.PingHost);
                         endpointsStatusExport_Summary_WorkSheet.Cell("D16").SetValue("DNS / MAC Lookup on Host");
-                        endpointsStatusExport_Summary_WorkSheet.Cell("E16").SetValue(dnsLookupOnHost);
+                        endpointsStatusExport_Summary_WorkSheet.Cell("E16").SetValue(summary.DnsLookupOnHost);
 
                         // SETTINGS FOR HTTP ENDPOINTS WORKSHEET
                         endpointsStatusExport_HTTP_WorkSheet.Style

--- a/src/EndpointExportRunSummary.cs
+++ b/src/EndpointExportRunSummary.cs
@@ -1,0 +1,98 @@
+namespace EndpointChecker
+{
+    internal sealed class EndpointExportRunSummary
+    {
+        private EndpointExportRunSummary(
+            string startDateTime,
+            string endDateTime,
+            int durationSeconds,
+            int pingTimeoutSeconds,
+            int httpRequestTimeoutSeconds,
+            int ftpRequestTimeoutSeconds,
+            string httpAutoRedirection,
+            string sslCertificateValidation,
+            string threadsCount,
+            string resolveNetworkShares,
+            string resolvePageMetaInfo,
+            string saveResponse,
+            string pingHost,
+            string dnsLookupOnHost)
+        {
+            StartDateTime = startDateTime;
+            EndDateTime = endDateTime;
+            DurationSeconds = durationSeconds;
+            PingTimeoutSeconds = pingTimeoutSeconds;
+            HttpRequestTimeoutSeconds = httpRequestTimeoutSeconds;
+            FtpRequestTimeoutSeconds = ftpRequestTimeoutSeconds;
+            HttpAutoRedirection = httpAutoRedirection;
+            SslCertificateValidation = sslCertificateValidation;
+            ThreadsCount = threadsCount;
+            ResolveNetworkShares = resolveNetworkShares;
+            ResolvePageMetaInfo = resolvePageMetaInfo;
+            SaveResponse = saveResponse;
+            PingHost = pingHost;
+            DnsLookupOnHost = dnsLookupOnHost;
+        }
+
+        public string StartDateTime { get; }
+
+        public string EndDateTime { get; }
+
+        public int DurationSeconds { get; }
+
+        public int PingTimeoutSeconds { get; }
+
+        public int HttpRequestTimeoutSeconds { get; }
+
+        public int FtpRequestTimeoutSeconds { get; }
+
+        public string HttpAutoRedirection { get; }
+
+        public string SslCertificateValidation { get; }
+
+        public string ThreadsCount { get; }
+
+        public string ResolveNetworkShares { get; }
+
+        public string ResolvePageMetaInfo { get; }
+
+        public string SaveResponse { get; }
+
+        public string PingHost { get; }
+
+        public string DnsLookupOnHost { get; }
+
+        public static EndpointExportRunSummary Create(
+            string startDateTime,
+            string endDateTime,
+            int durationSeconds,
+            int pingTimeoutSeconds,
+            int httpRequestTimeoutSeconds,
+            int ftpRequestTimeoutSeconds,
+            string httpAutoRedirection,
+            string sslCertificateValidation,
+            string threadsCount,
+            string resolveNetworkShares,
+            string resolvePageMetaInfo,
+            string saveResponse,
+            string pingHost,
+            string dnsLookupOnHost)
+        {
+            return new EndpointExportRunSummary(
+                startDateTime,
+                endDateTime,
+                durationSeconds,
+                pingTimeoutSeconds,
+                httpRequestTimeoutSeconds,
+                ftpRequestTimeoutSeconds,
+                httpAutoRedirection,
+                sslCertificateValidation,
+                threadsCount,
+                resolveNetworkShares,
+                resolvePageMetaInfo,
+                saveResponse,
+                pingHost,
+                dnsLookupOnHost);
+        }
+    }
+}

--- a/tests/ExportRunSummary.Tests/EndpointExportRunSummaryTests.cs
+++ b/tests/ExportRunSummary.Tests/EndpointExportRunSummaryTests.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal static class EndpointExportRunSummaryTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("Snapshot preserves export summary values", SnapshotPreservesExportSummaryValues);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void SnapshotPreservesExportSummaryValues()
+        {
+            EndpointExportRunSummary summary = EndpointExportRunSummary.Create(
+                "01.08.2026 10:00:00",
+                "01.08.2026 10:00:05",
+                5,
+                1,
+                2,
+                3,
+                "Enabled",
+                "Disabled",
+                "4",
+                "Enabled",
+                "Disabled",
+                "Enabled",
+                "Disabled",
+                "Enabled");
+
+            AssertEqual("01.08.2026 10:00:00", summary.StartDateTime);
+            AssertEqual("01.08.2026 10:00:05", summary.EndDateTime);
+            AssertEqual(5, summary.DurationSeconds);
+            AssertEqual(1, summary.PingTimeoutSeconds);
+            AssertEqual(2, summary.HttpRequestTimeoutSeconds);
+            AssertEqual(3, summary.FtpRequestTimeoutSeconds);
+            AssertEqual("Enabled", summary.HttpAutoRedirection);
+            AssertEqual("Disabled", summary.SslCertificateValidation);
+            AssertEqual("4", summary.ThreadsCount);
+            AssertEqual("Enabled", summary.ResolveNetworkShares);
+            AssertEqual("Disabled", summary.ResolvePageMetaInfo);
+            AssertEqual("Enabled", summary.SaveResponse);
+            AssertEqual("Disabled", summary.PingHost);
+            AssertEqual("Enabled", summary.DnsLookupOnHost);
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+}

--- a/tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
+++ b/tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointExportRunSummary.cs" Link="EndpointExportRunSummary.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an internal EndpointExportRunSummary snapshot for export summary metadata
- keep the existing public EndpointsStatusExport signature as a compatibility wrapper
- route the internal export writer through the summary snapshot
- add dependency-free characterization tests for the summary values

## Verification
- dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q

Note: app build still emits the existing NU1900/SYSLIB/CA1416 warnings; there are 0 errors.