### PR TITLE
Extract export file set

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -130,9 +130,9 @@ Verification:
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q`
 
-## Ticket 4: Export options and run-summary snapshots
+## Ticket 4: Export snapshots and file paths
 
-Status: In progress on `refactor/v3-export-run-summary`
+Status: In progress on `refactor/v3-export-file-names`
 
 Base branch: `v3-main`
 
@@ -149,6 +149,9 @@ Scope completed in this ticket:
 - Extracted `EndpointExportRunSummary` for the check/run metadata written to the export summary worksheet.
 - Kept the existing public `EndpointsStatusExport(...)` signature as a wrapper and moved the internal writer path to the summary snapshot.
 - Added dependency-free characterization tests for the export run-summary snapshot.
+- Extracted `EndpointExportFileSet` for legacy export file names and combined paths.
+- Replaced repeated export path construction in export generation and export-folder validation with the file-set snapshot.
+- Added dependency-free characterization tests for legacy export file names and path combination.
 
 Non-goals:
 
@@ -161,9 +164,11 @@ Tests:
 
 - `tests/ExportOptions.Tests` covers the export-options snapshot.
 - `tests/ExportRunSummary.Tests` covers the export run-summary snapshot.
+- `tests/ExportFileSet.Tests` covers legacy export file names and path combination.
 
 Verification:
 
+- `dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj`
 - `dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj`
 - `dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj`
 - `dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -2924,6 +2924,7 @@ namespace EndpointChecker
                 cb_ExportEndpointsStatus_XML.Checked,
                 cb_ExportEndpointsStatus_XLSX.Checked,
                 cb_ExportEndpointsStatus_HTML.Checked);
+            EndpointExportFileSet exportFiles = CreateEndpointExportFileSet();
 
             // ERROR LIST
             List<string> errorsList = new List<string>();
@@ -2958,8 +2959,8 @@ namespace EndpointChecker
                         try
                         {
                             CloseFileStream(definitionsStatusExport_JSON_FileStream);
-                            File.WriteAllText(Path.Combine(statusExport_Directory, statusExport_JSONFile), jsonString, Encoding.UTF8);
-                            definitionsStatusExport_JSON_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_JSONFile));
+                            File.WriteAllText(exportFiles.JsonPath, jsonString, Encoding.UTF8);
+                            definitionsStatusExport_JSON_FileStream = OpenFileStream(exportFiles.JsonPath);
                         }
                         catch (Exception ex)
                         {
@@ -2981,8 +2982,8 @@ namespace EndpointChecker
                         try
                         {
                             CloseFileStream(definitionsStatusExport_XML_FileStream);
-                            xmlExport.Save(Path.Combine(statusExport_Directory, statusExport_XMLFile));
-                            definitionsStatusExport_XML_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_XMLFile));
+                            xmlExport.Save(exportFiles.XmlPath);
+                            definitionsStatusExport_XML_FileStream = OpenFileStream(exportFiles.XmlPath);
                         }
                         catch (Exception ex)
                         {
@@ -3269,8 +3270,8 @@ namespace EndpointChecker
                             // SAVE XLSX
                             Application.DoEvents();
                             CloseFileStream(definitionsStatusExport_XLSX_FileStream);
-                            endpointsStatusExport_WorkBook.SaveAs(Path.Combine(statusExport_Directory, statusExport_XLSFile), new SaveOptions { ValidatePackage = true });
-                            definitionsStatusExport_XLSX_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_XLSFile));
+                            endpointsStatusExport_WorkBook.SaveAs(exportFiles.XlsxPath, new SaveOptions { ValidatePackage = true });
+                            definitionsStatusExport_XLSX_FileStream = OpenFileStream(exportFiles.XlsxPath);
                             Application.DoEvents();
                         }
                         catch (Exception ex)
@@ -3289,7 +3290,7 @@ namespace EndpointChecker
 
                             // SAVE AND LOCK HTML(S)
                             Workbook xlsxWorkBook = new Workbook();
-                            xlsxWorkBook.LoadFromFile(Path.Combine(statusExport_Directory, statusExport_XLSFile));
+                            xlsxWorkBook.LoadFromFile(exportFiles.XlsxPath);
 
                             Worksheet summaryWorkSheet = xlsxWorkBook.Worksheets["Summary"];
 
@@ -3333,21 +3334,21 @@ namespace EndpointChecker
 
                                     // SAVE HTML [HTTP PAGE]
                                     Application.DoEvents();
-                                    xlsxWorkBook.Worksheets["HTTP Endpoints"].SaveToHtml(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage));
+                                    xlsxWorkBook.Worksheets["HTTP Endpoints"].SaveToHtml(exportFiles.HtmlHttpPath);
                                     Application.DoEvents();
 
                                     // ADD 'HTTP' HTML FIXED REFRESH BUTTON
-                                    string httpHTMLString = File.ReadAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage));
+                                    string httpHTMLString = File.ReadAllText(exportFiles.HtmlHttpPath);
                                     httpHTMLString = CreateEndpointURLHyperLink(httpHTMLString);
                                     httpHTMLString = AddRefreshCSSButtonToHTMLString(httpHTMLString);
 
                                     // SAVE HTML STRING [HTTP PAGE]
                                     Application.DoEvents();
-                                    File.WriteAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage), httpHTMLString, Encoding.UTF8);
+                                    File.WriteAllText(exportFiles.HtmlHttpPath, httpHTMLString, Encoding.UTF8);
                                     Application.DoEvents();
 
                                     // LOCK 'HTTP' HTML
-                                    definitionsStatusExport_HTML_HTTP_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage));
+                                    definitionsStatusExport_HTML_HTTP_FileStream = OpenFileStream(exportFiles.HtmlHttpPath);
 
                                     // ADD 'HTTP' HYPERLINK PLACEHOLDER TO 'SUMMARY' PAGE           
                                     RichText httpPageHyperlink = summaryWorkSheet["A14"].RichText;
@@ -3371,21 +3372,21 @@ namespace EndpointChecker
                                 {
                                     // SAVE HTML [FTP PAGE]
                                     Application.DoEvents();
-                                    xlsxWorkBook.Worksheets["FTP Endpoints"].SaveToHtml(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage));
+                                    xlsxWorkBook.Worksheets["FTP Endpoints"].SaveToHtml(exportFiles.HtmlFtpPath);
                                     Application.DoEvents();
 
                                     // ADD 'FTP' HTML FIXED REFRESH BUTTON
-                                    string ftpHTMLString = File.ReadAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage));
+                                    string ftpHTMLString = File.ReadAllText(exportFiles.HtmlFtpPath);
                                     ftpHTMLString = CreateEndpointURLHyperLink(ftpHTMLString);
                                     ftpHTMLString = AddRefreshCSSButtonToHTMLString(ftpHTMLString);
 
                                     // SAVE HTML STRING [FTP PAGE]
                                     Application.DoEvents();
-                                    File.WriteAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage), ftpHTMLString, Encoding.UTF8);
+                                    File.WriteAllText(exportFiles.HtmlFtpPath, ftpHTMLString, Encoding.UTF8);
                                     Application.DoEvents();
 
                                     // LOCK 'FTP' HTML
-                                    definitionsStatusExport_HTML_FTP_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage));
+                                    definitionsStatusExport_HTML_FTP_FileStream = OpenFileStream(exportFiles.HtmlFtpPath);
 
                                     // ADD 'FTP' HYPERLINK PLACEHOLDER TO 'SUMMARY' PAGE           
                                     RichText ftpPageHyperlink = summaryWorkSheet["A15"].RichText;
@@ -3407,28 +3408,28 @@ namespace EndpointChecker
                             {
                                 // SAVE HTML [SUMMARY PAGE]
                                 Application.DoEvents();
-                                summaryWorkSheet.SaveToHtml(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage));
+                                summaryWorkSheet.SaveToHtml(exportFiles.HtmlInfoPath);
                                 Application.DoEvents();
 
                                 // REPLACE HYPERLINKS ON 'SUMMARY' PAGE
-                                string summaryHTMLstring = File.ReadAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage));
+                                string summaryHTMLstring = File.ReadAllText(exportFiles.HtmlInfoPath);
                                 summaryHTMLstring = summaryHTMLstring
-                                    .Replace("xHTML_XLSXx", "<a href=\"" + statusExport_XLSFile + "\" style=\"color:white;\">Endpoints Status XLSX Export</a>")
-                                    .Replace("xHTML_JSONx", "<a href=\"" + statusExport_JSONFile + "\" style=\"color:white;\">Endpoints Status JSON Export</a>")
-                                    .Replace("xHTML_XMLx", "<a href=\"" + statusExport_XMLFile + "\" style=\"color:white;\">Endpoints Status XML Export</a>")
-                                    .Replace("xHTML_HTTPx", "<a href=\"" + statusExport_HTMLFile_HTTPPage + "\" style=\"color:white;\">HTTP Endpoints Status List</a>")
-                                    .Replace("xHTML_FTPx", "<a href=\"" + statusExport_HTMLFile_FTPPage + "\" style=\"color:white;\">FTP Endpoints Status List</a>");
+                                    .Replace("xHTML_XLSXx", "<a href=\"" + exportFiles.XlsxFileName + "\" style=\"color:white;\">Endpoints Status XLSX Export</a>")
+                                    .Replace("xHTML_JSONx", "<a href=\"" + exportFiles.JsonFileName + "\" style=\"color:white;\">Endpoints Status JSON Export</a>")
+                                    .Replace("xHTML_XMLx", "<a href=\"" + exportFiles.XmlFileName + "\" style=\"color:white;\">Endpoints Status XML Export</a>")
+                                    .Replace("xHTML_HTTPx", "<a href=\"" + exportFiles.HtmlHttpFileName + "\" style=\"color:white;\">HTTP Endpoints Status List</a>")
+                                    .Replace("xHTML_FTPx", "<a href=\"" + exportFiles.HtmlFtpFileName + "\" style=\"color:white;\">FTP Endpoints Status List</a>");
 
                                 // ADD HTML AUTO REFRESH
                                 summaryHTMLstring = AddAutoRefreshToHTMLString(summaryHTMLstring, 30);
 
                                 // SAVE HTML STRING [SUMMARY PAGE]
                                 Application.DoEvents();
-                                File.WriteAllText(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage), summaryHTMLstring, Encoding.UTF8);
+                                File.WriteAllText(exportFiles.HtmlInfoPath, summaryHTMLstring, Encoding.UTF8);
                                 Application.DoEvents();
 
                                 // LOCK 'SUMMARY' HTML
-                                definitionsStatusExport_HTML_Info_FileStream = OpenFileStream(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage));
+                                definitionsStatusExport_HTML_Info_FileStream = OpenFileStream(exportFiles.HtmlInfoPath);
                             }
                             catch (Exception ex)
                             {
@@ -4478,6 +4479,18 @@ namespace EndpointChecker
                             MessageBoxIcon.Warning);
         }
 
+        private EndpointExportFileSet CreateEndpointExportFileSet()
+        {
+            return EndpointExportFileSet.Create(
+                statusExport_Directory,
+                statusExport_XLSFile,
+                statusExport_JSONFile,
+                statusExport_XMLFile,
+                statusExport_HTMLFile_InfoPage,
+                statusExport_HTMLFile_HTTPPage,
+                statusExport_HTMLFile_FTPPage);
+        }
+
         public void btn_BrowseExportDir_MouseClick(object sender, MouseEventArgs e)
         {
             if (Directory.Exists(statusExport_Directory))
@@ -4488,32 +4501,33 @@ namespace EndpointChecker
             if (folderBrowserExportDir.ShowDialog() == DialogResult.OK)
             {
                 statusExport_Directory = folderBrowserExportDir.SelectedPath;
+                EndpointExportFileSet exportFiles = CreateEndpointExportFileSet();
 
                 try
                 {
                     CloseFileStream(definitionsStatusExport_JSON_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_JSONFile))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_JSONFile));
+                    using (File.Create(exportFiles.JsonPath)) { }
+                    File.Delete(exportFiles.JsonPath);
 
                     CloseFileStream(definitionsStatusExport_XML_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_XMLFile))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_XMLFile));
+                    using (File.Create(exportFiles.XmlPath)) { }
+                    File.Delete(exportFiles.XmlPath);
 
                     CloseFileStream(definitionsStatusExport_XLSX_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_XLSFile))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_XLSFile));
+                    using (File.Create(exportFiles.XlsxPath)) { }
+                    File.Delete(exportFiles.XlsxPath);
 
                     CloseFileStream(definitionsStatusExport_HTML_Info_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_HTMLFile_InfoPage));
+                    using (File.Create(exportFiles.HtmlInfoPath)) { }
+                    File.Delete(exportFiles.HtmlInfoPath);
 
                     CloseFileStream(definitionsStatusExport_HTML_HTTP_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_HTMLFile_HTTPPage));
+                    using (File.Create(exportFiles.HtmlHttpPath)) { }
+                    File.Delete(exportFiles.HtmlHttpPath);
 
                     CloseFileStream(definitionsStatusExport_HTML_FTP_FileStream);
-                    using (File.Create(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage))) { }
-                    File.Delete(Path.Combine(statusExport_Directory, statusExport_HTMLFile_FTPPage));
+                    using (File.Create(exportFiles.HtmlFtpPath)) { }
+                    File.Delete(exportFiles.HtmlFtpPath);
                 }
                 catch (Exception exception)
                 {

--- a/src/EndpointExportFileSet.cs
+++ b/src/EndpointExportFileSet.cs
@@ -1,0 +1,70 @@
+using System.IO;
+
+namespace EndpointChecker
+{
+    internal sealed class EndpointExportFileSet
+    {
+        private EndpointExportFileSet(
+            string directory,
+            string xlsxFileName,
+            string jsonFileName,
+            string xmlFileName,
+            string htmlInfoFileName,
+            string htmlHttpFileName,
+            string htmlFtpFileName)
+        {
+            Directory = directory;
+            XlsxFileName = xlsxFileName;
+            JsonFileName = jsonFileName;
+            XmlFileName = xmlFileName;
+            HtmlInfoFileName = htmlInfoFileName;
+            HtmlHttpFileName = htmlHttpFileName;
+            HtmlFtpFileName = htmlFtpFileName;
+        }
+
+        public string Directory { get; }
+
+        public string XlsxFileName { get; }
+
+        public string JsonFileName { get; }
+
+        public string XmlFileName { get; }
+
+        public string HtmlInfoFileName { get; }
+
+        public string HtmlHttpFileName { get; }
+
+        public string HtmlFtpFileName { get; }
+
+        public string XlsxPath => Path.Combine(Directory, XlsxFileName);
+
+        public string JsonPath => Path.Combine(Directory, JsonFileName);
+
+        public string XmlPath => Path.Combine(Directory, XmlFileName);
+
+        public string HtmlInfoPath => Path.Combine(Directory, HtmlInfoFileName);
+
+        public string HtmlHttpPath => Path.Combine(Directory, HtmlHttpFileName);
+
+        public string HtmlFtpPath => Path.Combine(Directory, HtmlFtpFileName);
+
+        public static EndpointExportFileSet Create(
+            string directory,
+            string xlsxFileName,
+            string jsonFileName,
+            string xmlFileName,
+            string htmlInfoFileName,
+            string htmlHttpFileName,
+            string htmlFtpFileName)
+        {
+            return new EndpointExportFileSet(
+                directory,
+                xlsxFileName,
+                jsonFileName,
+                xmlFileName,
+                htmlInfoFileName,
+                htmlHttpFileName,
+                htmlFtpFileName);
+        }
+    }
+}

--- a/tests/ExportFileSet.Tests/EndpointExportFileSetTests.cs
+++ b/tests/ExportFileSet.Tests/EndpointExportFileSetTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+
+namespace EndpointChecker
+{
+    internal static class EndpointExportFileSetTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("File set preserves export file names", FileSetPreservesExportFileNames);
+            Run("File set combines directory and file names", FileSetCombinesDirectoryAndFileNames);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void FileSetPreservesExportFileNames()
+        {
+            EndpointExportFileSet files = CreateFileSet();
+
+            AssertEqual("EndpointsStatus.xlsx", files.XlsxFileName);
+            AssertEqual("EndpointsStatus.json", files.JsonFileName);
+            AssertEqual("EndpointsStatus.xml", files.XmlFileName);
+            AssertEqual("EndpointsStatus_Info.html", files.HtmlInfoFileName);
+            AssertEqual("EndpointsStatus_HTTP.html", files.HtmlHttpFileName);
+            AssertEqual("EndpointsStatus_FTP.html", files.HtmlFtpFileName);
+        }
+
+        private static void FileSetCombinesDirectoryAndFileNames()
+        {
+            EndpointExportFileSet files = CreateFileSet();
+
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus.xlsx"), files.XlsxPath);
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus.json"), files.JsonPath);
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus.xml"), files.XmlPath);
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus_Info.html"), files.HtmlInfoPath);
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus_HTTP.html"), files.HtmlHttpPath);
+            AssertEqual(Path.Combine("/tmp/export", "EndpointsStatus_FTP.html"), files.HtmlFtpPath);
+        }
+
+        private static EndpointExportFileSet CreateFileSet()
+        {
+            return EndpointExportFileSet.Create(
+                "/tmp/export",
+                "EndpointsStatus.xlsx",
+                "EndpointsStatus.json",
+                "EndpointsStatus.xml",
+                "EndpointsStatus_Info.html",
+                "EndpointsStatus_HTTP.html",
+                "EndpointsStatus_FTP.html");
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+}

--- a/tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
+++ b/tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\EndpointExportFileSet.cs" Link="EndpointExportFileSet.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add an internal EndpointExportFileSet for legacy export file names and combined paths
- replace repeated export Path.Combine calls in export generation and folder validation
- keep Program export filename fields and public behavior unchanged
- add dependency-free characterization tests for file names and path composition

## Verification
- dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
- dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q

Note: app build still emits the existing NU1900/SYSLIB/CA1416 warnings; there are 0 errors.