### PR TITLE
Extract structured export generation

### DIFF
--- a/refactoring-programme.md
+++ b/refactoring-programme.md
@@ -130,9 +130,9 @@ Verification:
 - `dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj`
 - `dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q`
 
-## Ticket 4: Export snapshots and file paths
+## Ticket 4: Export snapshots, file paths, and structured export generation
 
-Status: In progress on `refactor/v3-export-file-names`
+Status: In progress on `refactor/v3-structured-export-generation`
 
 Base branch: `v3-main`
 
@@ -152,6 +152,9 @@ Scope completed in this ticket:
 - Extracted `EndpointExportFileSet` for legacy export file names and combined paths.
 - Replaced repeated export path construction in export generation and export-folder validation with the file-set snapshot.
 - Added dependency-free characterization tests for legacy export file names and path combination.
+- Extracted JSON and XML export document creation into `EndpointStructuredExportGenerator`.
+- Preserved indented JSON output and the existing `Encoding+` to `Encoding_` XML workaround.
+- Added characterization tests for structured export output shape.
 
 Non-goals:
 
@@ -165,9 +168,11 @@ Tests:
 - `tests/ExportOptions.Tests` covers the export-options snapshot.
 - `tests/ExportRunSummary.Tests` covers the export run-summary snapshot.
 - `tests/ExportFileSet.Tests` covers legacy export file names and path combination.
+- `tests/StructuredExport.Tests` covers JSON and XML export generation.
 
 Verification:
 
+- `dotnet run --project tests/StructuredExport.Tests/StructuredExport.Tests.csproj`
 - `dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj`
 - `dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj`
 - `dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj`

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -2946,7 +2946,7 @@ namespace EndpointChecker
                 if (exportOptions.StructuredText)
                 {
                     // SERIALIZE ENDPOINTS LIST TO JSON
-                    string jsonString = JsonConvert.SerializeObject(exportList, Newtonsoft.Json.Formatting.Indented);
+                    string jsonString = EndpointStructuredExportGenerator.CreateJson(exportList);
 
                     if (exportOptions.Json)
                     {
@@ -2977,7 +2977,7 @@ namespace EndpointChecker
                         // ==========
                         // UNLOCK, SAVE AND LOCK XML
                         SetProgressStatus(0, 0, "Generating Endpoint Status XML Export ...", Color.BlueViolet);
-                        XmlDocument xmlExport = JsonConvert.DeserializeXmlNode("{\"EndpointStatus\":" + jsonString.Replace("Encoding+", "Encoding_") + "}", "EndpointStatus");
+                        XmlDocument xmlExport = EndpointStructuredExportGenerator.CreateXmlDocument(jsonString);
 
                         try
                         {

--- a/src/EndpointStructuredExportGenerator.cs
+++ b/src/EndpointStructuredExportGenerator.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace EndpointChecker
+{
+    internal static class EndpointStructuredExportGenerator
+    {
+        public static string CreateJson(IEnumerable<EndpointDefinition> endpoints)
+        {
+            return JsonConvert.SerializeObject(endpoints, Newtonsoft.Json.Formatting.Indented);
+        }
+
+        public static XmlDocument CreateXmlDocument(string json)
+        {
+            return JsonConvert.DeserializeXmlNode("{\"EndpointStatus\":" + json.Replace("Encoding+", "Encoding_") + "}", "EndpointStatus");
+        }
+    }
+}

--- a/tests/StructuredExport.Tests/EndpointStructuredExportGeneratorTests.cs
+++ b/tests/StructuredExport.Tests/EndpointStructuredExportGeneratorTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace EndpointChecker
+{
+    internal static class EndpointStructuredExportGeneratorTests
+    {
+        private static int failed;
+
+        private static void Main()
+        {
+            Run("JSON export remains indented", JsonExportRemainsIndented);
+            Run("XML export preserves root shape", XmlExportPreservesRootShape);
+            Run("XML export preserves Encoding plus workaround", XmlExportPreservesEncodingPlusWorkaround);
+
+            if (failed > 0)
+            {
+                Environment.Exit(1);
+            }
+        }
+
+        private static void JsonExportRemainsIndented()
+        {
+            string json = EndpointStructuredExportGenerator.CreateJson(new[]
+            {
+                new EndpointDefinition { Name = "Endpoint A", Address = "https://example.test" }
+            });
+
+            AssertContains(Environment.NewLine, json);
+            AssertContains("  \"Name\": \"Endpoint A\"", json);
+            AssertContains("  \"Address\": \"https://example.test\"", json);
+        }
+
+        private static void XmlExportPreservesRootShape()
+        {
+            string json = EndpointStructuredExportGenerator.CreateJson(new[]
+            {
+                new EndpointDefinition { Name = "Endpoint A", Address = "https://example.test" }
+            });
+
+            XmlDocument document = EndpointStructuredExportGenerator.CreateXmlDocument(json);
+
+            AssertEqual("EndpointStatus", document.DocumentElement.Name);
+            AssertEqual("Endpoint A", document.DocumentElement.SelectSingleNode("EndpointStatus/Name").InnerText);
+            AssertEqual("https://example.test", document.DocumentElement.SelectSingleNode("EndpointStatus/Address").InnerText);
+        }
+
+        private static void XmlExportPreservesEncodingPlusWorkaround()
+        {
+            string json = "[{\"Encoding+Name\":\"utf-8\"}]";
+
+            XmlDocument document = EndpointStructuredExportGenerator.CreateXmlDocument(json);
+
+            AssertEqual("utf-8", document.DocumentElement.SelectSingleNode("EndpointStatus/Encoding_Name").InnerText);
+        }
+
+        private static void Run(string name, Action test)
+        {
+            try
+            {
+                test();
+                Console.WriteLine("PASS " + name);
+            }
+            catch (Exception exception)
+            {
+                failed++;
+                Console.WriteLine("FAIL " + name + ": " + exception.Message);
+            }
+        }
+
+        private static void AssertContains(string expected, string actual)
+        {
+            if (actual == null || !actual.Contains(expected))
+            {
+                throw new InvalidOperationException("Expected text to contain <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+
+        private static void AssertEqual<T>(T expected, T actual)
+        {
+            if (!object.Equals(expected, actual))
+            {
+                throw new InvalidOperationException("Expected <" + expected + "> but was <" + actual + ">.");
+            }
+        }
+    }
+
+    public class EndpointDefinition
+    {
+        public string Name { get; set; }
+
+        public string Address { get; set; }
+    }
+}

--- a/tests/StructuredExport.Tests/StructuredExport.Tests.csproj
+++ b/tests/StructuredExport.Tests/StructuredExport.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <Compile Include="..\..\src\EndpointStructuredExportGenerator.cs" Link="EndpointStructuredExportGenerator.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add EndpointStructuredExportGenerator for JSON serialization and XML document creation
- preserve indented JSON output
- preserve the legacy nested XML shape and Encoding+ to Encoding_ workaround
- keep file writing, locking, and UI progress in CheckerMainForm

## Verification
- dotnet run --project tests/StructuredExport.Tests/StructuredExport.Tests.csproj
- dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
- dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:q

Note: one parallel test run hit a transient Roslyn mutex/runtime failure; rerunning the affected suites sequentially passed. App build still emits existing NU1900/SYSLIB/CA1416 warnings; there are 0 errors.