### PR TITLE
Fix v3 endpoint progress completion count

### DIFF
--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -675,8 +675,6 @@ namespace EndpointChecker
                         (int)num_FTPRequestTimeout.Value);
                 });
 
-                int endpointsCount_Current = 0;
-
                 // TextBox.Text calls GetWindowText (Win32) and throws
                 // InvalidOperationException from non-UI threads in .NET 5+.
                 // Capture the filter value on the UI thread before going parallel.
@@ -688,6 +686,8 @@ namespace EndpointChecker
                         eItem =>
                                  !endpointsList_Disabled.Contains(eItem.Name) &&
                                  eItem.Name.ToLower().Contains(listFilter)).Count();
+
+                EndpointCheckProgress endpointCheckProgress = new EndpointCheckProgress(endpointsCount_Enabled);
 
                 // FLUSH LOCAL DNS CACHE
                 DnsFlushResolverCache();
@@ -708,6 +708,8 @@ namespace EndpointChecker
                 // STORE PROGRESS START DATE/TIME [FOR 'EXPORT' AND 'AUTO ADJUST REFRESH INTERVAL' PURPOSES]
                 DateTime startDT_List = DateTime.Now;
 
+                SetProgressStatus(endpointCheckProgress.Snapshot);
+
                 // EXECUTE PARALLEL PROCESS 
                 Parallel.ForEach(
                     endpointsList,
@@ -722,6 +724,8 @@ namespace EndpointChecker
                         }
                         else
                         {
+                            EndpointCheckProgressWorkItem endpointProgressWorkItem = null;
+
                             try
                             {
                             // RESCAN ENDPOINT STATUS
@@ -741,11 +745,10 @@ namespace EndpointChecker
                                 // ENDPOINT IS ENABLED, GO ON
                                 if (!BW_GetStatus.CancellationPending)
                                 {
-                                    // INCREMENT PROGRESS COUNTER
-                                    Interlocked.Increment(ref endpointsCount_Current);
+                                    endpointProgressWorkItem = endpointCheckProgress.StartEndpoint();
 
                                     // SET PROGRESS STATUS LABEL
-                                    SetProgressStatus(endpointsCount_Enabled, endpointsCount_Current);
+                                    SetProgressStatus(endpointCheckProgress.Snapshot);
 
                                     // CREATE STOPWATCH FOR ITEM CHECK DURATION [FOR 'EXPORT' PURPOSE]
                                     Stopwatch sw_ItemProgress = new Stopwatch();
@@ -1371,8 +1374,6 @@ namespace EndpointChecker
                                         endpoint.MACAddress = endpointMACAddressStringList.ToArray();
                                     }
 
-                                    // SET PROGRESS STATUS LABEL
-                                    SetProgressStatus(endpointsCount_Enabled, endpointsCount_Current);
                                 }
                             }
 
@@ -1414,6 +1415,13 @@ namespace EndpointChecker
                                     updatedEndpointsList.Add(EndpointCheckResultFactory.CreateUnhandledExceptionResult(endpointItem, lambdaEx));
                                 }
                                 catch { /* if even the fallback fails, skip this endpoint */ }
+                            }
+                            finally
+                            {
+                                if (endpointProgressWorkItem != null)
+                                {
+                                    SetProgressStatus(endpointCheckProgress.CompleteEndpoint(endpointProgressWorkItem));
+                                }
                             }
                         }
                     });
@@ -2262,10 +2270,17 @@ namespace EndpointChecker
                 if (endpointsCount_Enabled > 0)
                 {
                     pb_RefreshProcess.Maximum = endpointsCount_Enabled;
-                    pb_RefreshProcess.Value   = endpointsCount_Current;
+                    pb_RefreshProcess.Value = Math.Min(
+                        endpointsCount_Enabled,
+                        Math.Max(0, endpointsCount_Current));
                 }
                 Application.DoEvents();
             });
+        }
+
+        private void SetProgressStatus(EndpointCheckProgressSnapshot progressSnapshot)
+        {
+            SetProgressStatus(progressSnapshot.TotalCount, progressSnapshot.CompletedCount);
         }
 
         public void btn_RunCheck_Click(object sender, EventArgs e)

--- a/src/EndpointCheckProgress.cs
+++ b/src/EndpointCheckProgress.cs
@@ -1,0 +1,73 @@
+using System.Threading;
+
+namespace EndpointChecker
+{
+    internal sealed class EndpointCheckProgress
+    {
+        private int completedCount;
+        private int activeCount;
+
+        public EndpointCheckProgress(int totalCount)
+        {
+            TotalCount = totalCount < 0 ? 0 : totalCount;
+        }
+
+        public int TotalCount { get; }
+
+        public EndpointCheckProgressSnapshot Snapshot =>
+            new EndpointCheckProgressSnapshot(
+                TotalCount,
+                Clamp(Volatile.Read(ref completedCount), 0, TotalCount),
+                Clamp(Volatile.Read(ref activeCount), 0, TotalCount));
+
+        public EndpointCheckProgressWorkItem StartEndpoint()
+        {
+            Interlocked.Increment(ref activeCount);
+            return new EndpointCheckProgressWorkItem();
+        }
+
+        public EndpointCheckProgressSnapshot CompleteEndpoint(EndpointCheckProgressWorkItem workItem)
+        {
+            if (workItem == null ||
+                !workItem.TryComplete())
+            {
+                return Snapshot;
+            }
+
+            int completed = Interlocked.Increment(ref completedCount);
+
+            int active;
+            do
+            {
+                active = Volatile.Read(ref activeCount);
+                if (active <= 0)
+                {
+                    break;
+                }
+            }
+            while (Interlocked.CompareExchange(ref activeCount, active - 1, active) != active);
+
+            if (completed > TotalCount)
+            {
+                Interlocked.Exchange(ref completedCount, TotalCount);
+            }
+
+            return Snapshot;
+        }
+
+        private static int Clamp(int value, int minimum, int maximum)
+        {
+            if (value < minimum)
+            {
+                return minimum;
+            }
+
+            if (value > maximum)
+            {
+                return maximum;
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/EndpointCheckProgressSnapshot.cs
+++ b/src/EndpointCheckProgressSnapshot.cs
@@ -1,0 +1,18 @@
+namespace EndpointChecker
+{
+    internal sealed class EndpointCheckProgressSnapshot
+    {
+        public EndpointCheckProgressSnapshot(int totalCount, int completedCount, int activeCount)
+        {
+            TotalCount = totalCount;
+            CompletedCount = completedCount;
+            ActiveCount = activeCount;
+        }
+
+        public int TotalCount { get; }
+
+        public int CompletedCount { get; }
+
+        public int ActiveCount { get; }
+    }
+}

--- a/src/EndpointCheckProgressWorkItem.cs
+++ b/src/EndpointCheckProgressWorkItem.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+
+namespace EndpointChecker
+{
+    internal sealed class EndpointCheckProgressWorkItem
+    {
+        private int completed;
+
+        public bool TryComplete()
+        {
+            return Interlocked.Exchange(ref completed, 1) == 0;
+        }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
@@ -10,6 +10,7 @@ namespace EndpointChecker
         {
             EndpointCheckOptionsTests.Register();
             EndpointCheckResultFactoryTests.Register();
+            EndpointCheckProgressTests.Register();
 
             if (failed > 0)
             {

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckProgressTests.cs
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckProgressTests.cs
@@ -1,0 +1,127 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal static class EndpointCheckProgressTests
+    {
+        public static void Register()
+        {
+            Run("Queued endpoint does not increment completed progress", QueuedEndpointDoesNotIncrementCompletedProgress);
+            Run("Starting endpoint does not increment completed progress", StartingEndpointDoesNotIncrementCompletedProgress);
+            Run("Completing endpoint increments completed progress once", CompletingEndpointIncrementsCompletedProgressOnce);
+            Run("Terminal failure increments completed progress once", TerminalFailureIncrementsCompletedProgressOnce);
+            Run("Progress never exceeds total endpoints", ProgressNeverExceedsTotalEndpoints);
+            Run("Completed count remains below total while checks remain active", CompletedCountRemainsBelowTotalWhileChecksRemainActive);
+            Run("Progress reaches total only after final endpoint terminates", ProgressReachesTotalOnlyAfterFinalEndpointTerminates);
+            Run("Cancellation terminal state increments completed progress once", CancellationTerminalStateIncrementsCompletedProgressOnce);
+        }
+
+        private static void QueuedEndpointDoesNotIncrementCompletedProgress()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(1);
+
+            EndpointCheckProgressSnapshot snapshot = progress.Snapshot;
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.TotalCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void StartingEndpointDoesNotIncrementCompletedProgress()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(1);
+
+            progress.StartEndpoint();
+            EndpointCheckProgressSnapshot snapshot = progress.Snapshot;
+
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.ActiveCount);
+        }
+
+        private static void CompletingEndpointIncrementsCompletedProgressOnce()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(1);
+            EndpointCheckProgressWorkItem workItem = progress.StartEndpoint();
+
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(workItem);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+
+            snapshot = progress.CompleteEndpoint(workItem);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void TerminalFailureIncrementsCompletedProgressOnce()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(2);
+            EndpointCheckProgressWorkItem successful = progress.StartEndpoint();
+            EndpointCheckProgressWorkItem failed = progress.StartEndpoint();
+
+            progress.CompleteEndpoint(successful);
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(failed);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(2, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void ProgressNeverExceedsTotalEndpoints()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(1);
+            EndpointCheckProgressWorkItem first = progress.StartEndpoint();
+            EndpointCheckProgressWorkItem second = progress.StartEndpoint();
+
+            progress.CompleteEndpoint(first);
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(second);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void CompletedCountRemainsBelowTotalWhileChecksRemainActive()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(3);
+            EndpointCheckProgressWorkItem first = progress.StartEndpoint();
+            progress.StartEndpoint();
+            progress.StartEndpoint();
+
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(first);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(2, snapshot.ActiveCount);
+            if (snapshot.CompletedCount >= snapshot.TotalCount)
+            {
+                throw new InvalidOperationException("Completed count reached total while checks were still active.");
+            }
+        }
+
+        private static void ProgressReachesTotalOnlyAfterFinalEndpointTerminates()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(2);
+            EndpointCheckProgressWorkItem first = progress.StartEndpoint();
+            EndpointCheckProgressWorkItem second = progress.StartEndpoint();
+
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(first);
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+
+            snapshot = progress.CompleteEndpoint(second);
+            EndpointCheckingCoreTestRunner.AssertEqual(2, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void CancellationTerminalStateIncrementsCompletedProgressOnce()
+        {
+            EndpointCheckProgress progress = new EndpointCheckProgress(1);
+            EndpointCheckProgressWorkItem cancelled = progress.StartEndpoint();
+
+            EndpointCheckProgressSnapshot snapshot = progress.CompleteEndpoint(cancelled);
+
+            EndpointCheckingCoreTestRunner.AssertEqual(1, snapshot.CompletedCount);
+            EndpointCheckingCoreTestRunner.AssertEqual(0, snapshot.ActiveCount);
+        }
+
+        private static void Run(string name, Action test) => EndpointCheckingCoreTestRunner.Run(name, test);
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
@@ -8,6 +8,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\src\EndpointCheckOptions.cs" Link="EndpointCheckOptions.cs" />
+    <Compile Include="..\..\src\EndpointCheckProgress.cs" Link="EndpointCheckProgress.cs" />
+    <Compile Include="..\..\src\EndpointCheckProgressSnapshot.cs" Link="EndpointCheckProgressSnapshot.cs" />
+    <Compile Include="..\..\src\EndpointCheckProgressWorkItem.cs" Link="EndpointCheckProgressWorkItem.cs" />
     <Compile Include="..\..\src\EndpointCheckResultFactory.cs" Link="EndpointCheckResultFactory.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- replace the scan progress counter with an explicit completed-endpoint progress state
- mark endpoint completion from the worker finalization path so success, handled failures, timeouts, and exceptions advance once
- add focused progress-state tests for queue/start/complete/cancellation and over-count protection

## Root cause
The previous progress counter was incremented when an enabled endpoint was assigned to a worker, before the endpoint check had reached a terminal state. With high parallelism or slow final checks, the UI could therefore show all endpoints complete while work was still running.

## Verification
- dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet clean src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -p:RunAnalyzers=true -v:minimal
- dotnet run --project tests/StructuredExport.Tests/StructuredExport.Tests.csproj
- dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
- dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- git diff --check
- dotnet format src/EndpointChecker.sln --verify-no-changes --no-restore (fails on pre-existing whitespace findings; no formatting churn included)