### PR TITLE
Prepare v3 prerelease test build state

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ a single scan with configurable automation.
 
 ---
 
-## What's New in v3.1
+## Current v3 Development Status
+
+Endpoint Status Checker v3 is currently developed on the `Main-Dev-V3` branch. There is no official v3 release published at this time, and the previous GitHub release artifacts have been removed.
+
+The in-app updater and standalone updater are intentionally disabled for v3 until an official release ZIP is published.
+
+## What's New in v3 Development
 
 | Area | Change |
 | --- | --- |
@@ -100,25 +106,21 @@ See [CHANGELOG.md](CHANGELOG.md) for the full technical change log.
 
 ### Fresh install
 
-1. Download [**EndpointChecker-v3.1.0-win-x86.zip**](https://github.com/ThePhOeNiX810815/Endpoint-Status-Checker/releases/download/v3.1.0/EndpointChecker-v3.1.0-win-x86.zip) from the [latest release](https://github.com/ThePhOeNiX810815/Endpoint-Status-Checker/releases/latest) (~100 MB — the .NET 10 runtime is bundled).
-2. Extract the archive to any folder. It will create its data files (`EndpointChecker_EndpointsList.txt`, `EndpointChecker_LastSeenOnline.json`) alongside `EndpointChecker.exe` on first run.
-3. Run `EndpointChecker.exe` as Administrator.
+No official v3 release package is currently available.
+
+For development or test builds, publish the application from the `Main-Dev-V3` branch and extract the generated self-contained output to any folder. The app will create its data files (`EndpointChecker_EndpointsList.txt`, `EndpointChecker_LastSeenOnline.json`) alongside `EndpointChecker.exe` on first run.
+
+Run `EndpointChecker.exe` as Administrator.
 
 No installer, no registry keys, no separate runtime — the self-contained build bundles everything.
 
 ### Upgrading from v2.15 or earlier
 
-Download and run [**EndpointChecker-Updater-v3.1.0-win-x86.exe**](https://github.com/ThePhOeNiX810815/Endpoint-Status-Checker/releases/download/v3.1.0/EndpointChecker-Updater-v3.1.0-win-x86.exe) (~46 MB, also self-contained).
+Automatic upgrading to v3 is currently unavailable because no official v3 release package is published.
 
-The updater will:
+When an official v3 release is prepared, the updater documentation will be updated to reference the release ZIP. Until then, keep v2.15 installations separate from manually supplied v3 test builds.
 
-- Auto-detect your existing install directory (or let you browse to it)
-- Stop the running application if open
-- Download and extract the new v3.1.0 package
-- Preserve your endpoint list and last-seen-online data
-- Launch the updated application when done
-
-> **Note:** v3.1.0 requires Windows 10 (build 1607) or later. Machines running Windows 7 / Server 2008 R2 can continue using v2.15.
+> **Note:** v3 development builds require Windows 10 (build 1607) or later. Machines running Windows 7 / Server 2008 R2 can continue using v2.15.
 
 ---
 

--- a/src/AutoUpdaterDialog.cs
+++ b/src/AutoUpdaterDialog.cs
@@ -15,15 +15,15 @@ namespace EndpointChecker
     public partial class AutoUpdaterDialog : Form
     {
         // Derived lazily so the class can be referenced before CheckForUpdate() sets the link.
-        private static string _zipFileName   => Path.GetFileName(new Uri(app_LatestPackageLink).AbsolutePath);
+        private static string _zipFileName => Path.GetFileName(new Uri(app_LatestPackageLink).AbsolutePath);
         private static string _extractFolder => "EndpointChecker_Update";
-        private static string _updateScript  =  string.Empty;
-        private static bool   _updateSuccess =  false;
+        private static string _updateScript = string.Empty;
+        private static bool _updateSuccess = false;
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
-        public const int HT_CAPTION       = 0x2;
+        public const int HT_CAPTION = 0x2;
 
-        [DllImport("user32.dll")] public static extern int  SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+        [DllImport("user32.dll")] public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
         [DllImport("user32.dll")] public static extern bool ReleaseCapture();
 
         public AutoUpdaterDialog()
@@ -31,12 +31,12 @@ namespace EndpointChecker
             InitializeComponent();
 
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(UnhandledExceptionHandler);
-            Application.ThreadException                += new ThreadExceptionEventHandler(ThreadExceptionHandler);
+            Application.ThreadException += new ThreadExceptionEventHandler(ThreadExceptionHandler);
 
             DoubleBuffered = true;
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
 
-            lbl_Name.Text    = app_ApplicationName;
+            lbl_Name.Text = app_ApplicationName;
             lbl_Copyright.Text = app_Copyright;
 
             lbl_UpdateVersion.Text =
@@ -60,9 +60,9 @@ namespace EndpointChecker
                 ThreadSafeInvoke(() => lbl_Progress.Text = "Downloading Package from GitHub ...");
                 Thread.Sleep(1000);
 
-                int  maxAttempts = 20;
-                int  attempt     = 0;
-                bool downloaded  = false;
+                int maxAttempts = 20;
+                int attempt = 0;
+                bool downloaded = false;
 
                 while (!downloaded && attempt < maxAttempts)
                 {
@@ -100,10 +100,10 @@ namespace EndpointChecker
                 // 5. SUCCESS
                 ThreadSafeInvoke(() =>
                 {
-                    lbl_Progress.Visible         = false;
+                    lbl_Progress.Visible = false;
                     lbl_UpdateStatus_Wait.Visible = false;
-                    lbl_UpdateStatus.ForeColor    = Color.Lime;
-                    lbl_UpdateStatus.Text         = "SUCCESSFULLY UPDATED";
+                    lbl_UpdateStatus.ForeColor = Color.Lime;
+                    lbl_UpdateStatus.Text = "SUCCESSFULLY UPDATED";
                 });
 
                 _updateSuccess = true;
@@ -113,10 +113,10 @@ namespace EndpointChecker
             {
                 ThreadSafeInvoke(() =>
                 {
-                    lbl_Progress.Visible         = false;
+                    lbl_Progress.Visible = false;
                     lbl_UpdateStatus_Wait.Visible = false;
-                    lbl_UpdateStatus.ForeColor    = Color.Red;
-                    lbl_UpdateStatus.Text         = "UPDATE FAILED";
+                    lbl_UpdateStatus.ForeColor = Color.Red;
+                    lbl_UpdateStatus.Text = "UPDATE FAILED";
                 });
 
                 Thread.Sleep(2000);
@@ -146,7 +146,7 @@ namespace EndpointChecker
                     Process.Start(new ProcessStartInfo(_updateScript)
                     {
                         UseShellExecute = true,
-                        WindowStyle     = ProcessWindowStyle.Minimized
+                        WindowStyle = ProcessWindowStyle.Minimized
                     });
                 }
 
@@ -167,10 +167,10 @@ namespace EndpointChecker
         private static void WriteUpdateScript()
         {
             string extractDir = Path.Combine(app_TempDir, _extractFolder);
-            string appDir     = app_CurrentWorkingDir;
-            string appExe     = Path.Combine(appDir, "EndpointChecker.exe");
-            string backupDir  = Path.Combine(app_TempDir, "EndpointChecker_UserData");
-            _updateScript     = Path.Combine(app_TempDir, "EndpointChecker_Update.cmd");
+            string appDir = app_CurrentWorkingDir;
+            string appExe = Path.Combine(appDir, "EndpointChecker.exe");
+            string backupDir = Path.Combine(app_TempDir, "EndpointChecker_UserData");
+            _updateScript = Path.Combine(app_TempDir, "EndpointChecker_Update.cmd");
 
             var sb = new StringBuilder();
             sb.AppendLine("@echo off");

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -293,7 +293,8 @@ namespace EndpointChecker
             toolTip_BrowseReportOutputFolder.SetToolTip(btn_BrowseExportDir, "Browse for Report(s) output folder");
 
             // SET TOOLTIP FOR 'RUN CHECK' BUTTON
-            ToolTip toolTip_LoadList = new ToolTip {
+            ToolTip toolTip_LoadList = new ToolTip
+            {
                 ToolTipIcon = ToolTipIcon.Warning,
                 IsBalloon = true,
                 ToolTipTitle = "Load Endpoints Definitions List"
@@ -728,298 +729,111 @@ namespace EndpointChecker
 
                             try
                             {
-                            // RESCAN ENDPOINT STATUS
-                            Uri endpointURI = new Uri(endpointItem.Address);
-                            Uri responseURI = new Uri(endpointItem.ResponseAddress);
-                            string durationTime_Item = status_NotAvailable;
+                                // RESCAN ENDPOINT STATUS
+                                Uri endpointURI = new Uri(endpointItem.Address);
+                                Uri responseURI = new Uri(endpointItem.ResponseAddress);
+                                string durationTime_Item = status_NotAvailable;
 
-                            EndpointDefinition endpoint = EndpointCheckResultFactory.CreatePendingResult(endpointItem);
+                                EndpointDefinition endpoint = EndpointCheckResultFactory.CreatePendingResult(endpointItem);
 
-                            if (endpointsList_Disabled.Contains(endpoint.Name))
-                            {
-                                // ENDPOINT IS DISBALED, DON'T CHECK
-                                endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.DISABLED);
-                            }
-                            else
-                            {
-                                // ENDPOINT IS ENABLED, GO ON
-                                if (!BW_GetStatus.CancellationPending)
+                                if (endpointsList_Disabled.Contains(endpoint.Name))
                                 {
-                                    endpointProgressWorkItem = endpointCheckProgress.StartEndpoint();
-
-                                    // SET PROGRESS STATUS LABEL
-                                    SetProgressStatus(endpointCheckProgress.Snapshot);
-
-                                    // CREATE STOPWATCH FOR ITEM CHECK DURATION [FOR 'EXPORT' PURPOSE]
-                                    Stopwatch sw_ItemProgress = new Stopwatch();
-
-                                    if (validationMethod == ValidationMethod.Protocol &&
-                                        !BW_GetStatus.CancellationPending &&
-                                        (endpoint.Protocol.ToLower() == Uri.UriSchemeHttp ||
-                                         endpoint.Protocol.ToLower() == Uri.UriSchemeHttps))
+                                    // ENDPOINT IS DISBALED, DON'T CHECK
+                                    endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.DISABLED);
+                                }
+                                else
+                                {
+                                    // ENDPOINT IS ENABLED, GO ON
+                                    if (!BW_GetStatus.CancellationPending)
                                     {
-                                        // AUTO-REDIRECT SWITCH [BY 'LOCATION' HEADER OF '3xx' RESPONSE CODE]
-                                        bool autoRedirect_Followed = false;
+                                        endpointProgressWorkItem = endpointCheckProgress.StartEndpoint();
 
-                                        // HTTP OR HTTPS PROTOCOL SCHEME
-                                        HttpWebRequest httpWebRequest = null;
-                                        HttpWebResponse httpWebResponse = null;
+                                        // SET PROGRESS STATUS LABEL
+                                        SetProgressStatus(endpointCheckProgress.Snapshot);
 
-                                        // START STOPWATCH FOR ITEM CHECK DURATION
-                                        sw_ItemProgress.Start();
+                                        // CREATE STOPWATCH FOR ITEM CHECK DURATION [FOR 'EXPORT' PURPOSE]
+                                        Stopwatch sw_ItemProgress = new Stopwatch();
 
-                                        try
+                                        if (validationMethod == ValidationMethod.Protocol &&
+                                            !BW_GetStatus.CancellationPending &&
+                                            (endpoint.Protocol.ToLower() == Uri.UriSchemeHttp ||
+                                             endpoint.Protocol.ToLower() == Uri.UriSchemeHttps))
                                         {
-                                            // PREPARE WEBREQUEST
-                                            httpWebRequest = PrepareHTTPWebRequest(
-                                                endpoint,
-                                                endpointURI,
-                                                checkOptions.HttpRequestTimeout,
-                                                checkOptions.AllowAutoRedirect,
-                                                checkOptions.RemoveUrlParameters);
+                                            // AUTO-REDIRECT SWITCH [BY 'LOCATION' HEADER OF '3xx' RESPONSE CODE]
+                                            bool autoRedirect_Followed = false;
+
+                                            // HTTP OR HTTPS PROTOCOL SCHEME
+                                            HttpWebRequest httpWebRequest = null;
+                                            HttpWebResponse httpWebResponse = null;
+
+                                            // START STOPWATCH FOR ITEM CHECK DURATION
+                                            sw_ItemProgress.Start();
 
                                             try
                                             {
-                                                // TRY TO GET RESPONSE
-                                                httpWebResponse = GetHTTPWebResponse(httpWebRequest, 3);
+                                                // PREPARE WEBREQUEST
+                                                httpWebRequest = PrepareHTTPWebRequest(
+                                                    endpoint,
+                                                    endpointURI,
+                                                    checkOptions.HttpRequestTimeout,
+                                                    checkOptions.AllowAutoRedirect,
+                                                    checkOptions.RemoveUrlParameters);
 
-                                                // HANDLE POSSIBLE REDIRECT [3xx]
-                                                if (checkOptions.AllowAutoRedirect && ((int)httpWebResponse.StatusCode).ToString().StartsWith("3"))
+                                                try
                                                 {
-                                                    throw new WebException(
-                                                        "HTTP Response Code: " + (int)httpWebResponse.StatusCode,
-                                                        null,
-                                                        WebExceptionStatus.UnknownError,
-                                                        httpWebResponse);
-                                                }
-                                            }
-                                            catch (WebException wEX)
-                                            {
-                                                // IF RESULT CODE IS '3xx', DO A SECOND CALL ON 'LOCATION'
-                                                if (checkOptions.AllowAutoRedirect &&
-                                                    wEX.Response is HttpWebResponse _httpWebResponse &&
-                                                    ((int)_httpWebResponse.StatusCode).ToString().StartsWith("3") &&
-                                                    _httpWebResponse.Headers.AllKeys.Contains("Location") &&
-                                                    !string.IsNullOrEmpty(_httpWebResponse.GetResponseHeader("Location")))
-                                                {
-                                                    // GET 'LOCATION' HEADER VALUE
-                                                    string locationHeaderValue = _httpWebResponse.GetResponseHeader("Location");
+                                                    // TRY TO GET RESPONSE
+                                                    httpWebResponse = GetHTTPWebResponse(httpWebRequest, 3);
 
-                                                    // IF IS RELATIVE PATH
-                                                    if (Uri.IsWellFormedUriString(locationHeaderValue, UriKind.Relative))
+                                                    // HANDLE POSSIBLE REDIRECT [3xx]
+                                                    if (checkOptions.AllowAutoRedirect && ((int)httpWebResponse.StatusCode).ToString().StartsWith("3"))
                                                     {
-                                                        locationHeaderValue = Url.Combine(_httpWebResponse.ResponseUri.OriginalString, locationHeaderValue);
+                                                        throw new WebException(
+                                                            "HTTP Response Code: " + (int)httpWebResponse.StatusCode,
+                                                            null,
+                                                            WebExceptionStatus.UnknownError,
+                                                            httpWebResponse);
                                                     }
-
-                                                    // PREPARE WEBREQUEST
-                                                    HttpWebRequest httpWebRequest_Redirected = PrepareHTTPWebRequest(
-                                                        endpoint,
-                                                        new Uri(locationHeaderValue),
-                                                        checkOptions.HttpRequestTimeout,
-                                                        checkOptions.AllowAutoRedirect,
-                                                        checkOptions.RemoveUrlParameters,
-                                                        _httpWebResponse.Cookies);
-
-                                                    autoRedirect_Followed = true;
-
-                                                    // GET RESPONSE FROM 'LOCATION'
-                                                    httpWebResponse = GetHTTPWebResponse(httpWebRequest_Redirected, 3);
                                                 }
-                                                else
+                                                catch (WebException wEX)
                                                 {
-                                                    throw;
-                                                }
-                                            }
-
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
-
-                                            // GET RESPONSE HEADERS
-                                            GetHTTPWebHeaders(endpoint.HTTPResponseHeaders.PropertyItem, httpWebResponse.Headers);
-
-                                            // GET SSL INFO
-                                            GetSSLCertificateInfo(httpWebRequest, endpoint);
-
-                                            responseURI = httpWebResponse.ResponseUri;
-                                            endpoint.Port = responseURI.Port.ToString();
-                                            endpoint.Protocol = responseURI.Scheme.ToUpper();
-                                            endpoint.ResponseCode = ((int)httpWebResponse.StatusCode).ToString();
-
-                                            // SERVER IDENTIFICATION
-                                            if (!string.IsNullOrEmpty(httpWebResponse.Server))
-                                            {
-                                                endpoint.ServerID = Regex.Replace(httpWebResponse.Server, "<.*?>", string.Empty);
-                                            }
-
-                                            // STATUS MESSAGE
-                                            if (!string.IsNullOrEmpty(httpWebResponse.StatusDescription))
-                                            {
-                                                // STATUS DESCRIPTION
-                                                endpoint.ResponseMessage = httpWebResponse.StatusDescription;
-                                            }
-                                            else
-                                            {
-                                                // STATUS CODE [STRING]
-                                                endpoint.ResponseMessage = httpWebResponse.StatusCode.ToString();
-                                            }
-
-                                            // GET AUTO REDIRECTS COUNT
-                                            if (checkOptions.AllowAutoRedirect)
-                                            {
-                                                FieldInfo fieldInfo = httpWebRequest.GetType().GetField("_AutoRedirects", BindingFlags.NonPublic | BindingFlags.Instance);
-                                                // _AutoRedirects was removed in .NET 10; guard against null fieldInfo
-                                                int httpAutoRedirects = fieldInfo != null ? (int)fieldInfo.GetValue(httpWebRequest) : 0;
-                                                endpoint.HTTPautoRedirects = httpAutoRedirects.ToString();
-
-                                                // CHECK AUTO REDIRECT URL [COMPARE REQUEST AND RESPONSE ENDPOINT URIs]
-                                                if (endpointURI.Scheme != responseURI.Scheme ||
-                                                    endpointURI.Port != responseURI.Port ||
-                                                    endpointURI.Host != responseURI.Host ||
-                                                    autoRedirect_Followed)
-                                                {
-                                                    endpoint.ResponseMessage += " (Redirected from \"" + endpointURI.OriginalString + "\")";
-                                                }
-                                            }
-
-                                            // GET 'CONTENT TYPE' META VALUE FROM RESPONSE HEADER
-                                            endpoint.HTTPcontentType = GetContentType(httpWebResponse.ContentType);
-
-                                            // GET 'EXPIRES' META VALUE FROM RESPONSE HEADER
-                                            DateTime _httpExpiresDT = DateTime.MinValue;
-                                            if (!string.IsNullOrEmpty(httpWebResponse.Headers["Expires"]) &&
-                                                TryParseHttpDate(httpWebResponse.Headers["Expires"], out _httpExpiresDT) &&
-                                                _httpExpiresDT > DateTime.MinValue)
-                                            {
-                                                endpoint.HTTPexpires = _httpExpiresDT.ToString("dd.MM.yyyy HH:mm");
-                                            }
-
-                                            // GET 'ETAG' META VALUE FROM RESPONSE HEADER
-                                            if (!string.IsNullOrEmpty(httpWebResponse.Headers["ETag"]))
-                                            {
-                                                endpoint.HTTPetag = httpWebResponse.Headers["ETag"]
-                                                    .ToString()
-                                                    .TrimStart()
-                                                    .TrimEnd()
-                                                    .TrimStart('"')
-                                                    .TrimEnd('"');
-                                            }
-
-                                            // GET CONTENT Length FROM RESPONSE HEADER
-                                            long contentLength = httpWebResponse.ContentLength;
-
-                                            if (!string.IsNullOrEmpty(httpWebResponse.Headers["Content-Length"]))
-                                            {
-                                                long.TryParse(httpWebResponse.Headers["Content-Length"], out contentLength);
-                                            }
-
-                                            GetWebResponseContentLengthString(endpoint, contentLength);
-
-                                            // TRY TO GET HEADER ENCODING FROM RESPONSE HEADER
-                                            endpoint.HTTPencoding = GetEncoding(httpWebResponse.ContentType);
-
-                                            if (checkOptions.SaveResponse || checkOptions.ResolvePageMetaInfo)
-                                            {
-                                                // GET RESPONSE STREAM
-                                                using (BinaryReader httpWebResponseBinaryReader = new BinaryReader(httpWebResponse.GetResponseStream()))
-                                                {
-                                                    MemoryStream httpWebResponseMemoryStream = new MemoryStream();
-
-                                                    byte[] httpWebResponseByteArray;
-                                                    byte[] httpWebResponseBuffer = httpWebResponseBinaryReader.ReadBytes(1024);
-                                                    while (httpWebResponseBuffer.Length > 0 && httpWebResponseMemoryStream.Length < (http_SaveResponse_MaxLength_Bytes + 1024))
+                                                    // IF RESULT CODE IS '3xx', DO A SECOND CALL ON 'LOCATION'
+                                                    if (checkOptions.AllowAutoRedirect &&
+                                                        wEX.Response is HttpWebResponse _httpWebResponse &&
+                                                        ((int)_httpWebResponse.StatusCode).ToString().StartsWith("3") &&
+                                                        _httpWebResponse.Headers.AllKeys.Contains("Location") &&
+                                                        !string.IsNullOrEmpty(_httpWebResponse.GetResponseHeader("Location")))
                                                     {
-                                                        httpWebResponseMemoryStream.Write(httpWebResponseBuffer, 0, httpWebResponseBuffer.Length);
-                                                        httpWebResponseBuffer = httpWebResponseBinaryReader.ReadBytes(1024);
-                                                    }
+                                                        // GET 'LOCATION' HEADER VALUE
+                                                        string locationHeaderValue = _httpWebResponse.GetResponseHeader("Location");
 
-                                                    httpWebResponseByteArray = new byte[(int)httpWebResponseMemoryStream.Length];
-                                                    httpWebResponseMemoryStream.Position = 0;
-                                                    httpWebResponseMemoryStream.Read(httpWebResponseByteArray, 0, httpWebResponseByteArray.Length);
-
-                                                    // GET CONTENT Length FROM FULL RESPONSE
-                                                    contentLength = httpWebResponseMemoryStream.Length;
-                                                    GetWebResponseContentLengthString(endpoint, contentLength);
-
-                                                    if (checkOptions.SaveResponse &&
-                                                        !string.IsNullOrEmpty(endpoint.HTTPcontentType) &&
-                                                        CheckWebResponseContentLength(endpoint, httpWebResponse, contentLength))
-                                                    {
-                                                        // GET FILE EXTENSION BY CONTENT TYPE
-                                                        string fileExtension = GetFileExtensionByContentType(endpoint.HTTPcontentType);
-
-                                                        // SAVE RESPONSE TO FILE
-                                                        SaveWebResponseStream(
-                                                                              startDT_List,
-                                                                              endpoint.Name,
-                                                                              httpWebResponseByteArray,
-                                                                              fileExtension);
-                                                    }
-
-                                                    if (endpoint.HTTPcontentType == "text/html")
-                                                    {
-                                                        // GET HTML METADATA
-                                                        if (checkOptions.ResolvePageMetaInfo)
+                                                        // IF IS RELATIVE PATH
+                                                        if (Uri.IsWellFormedUriString(locationHeaderValue, UriKind.Relative))
                                                         {
-                                                            // READ RESPONSE STREAM [HTTP HEADER ENCODING] AND GET HTML META INFO
-                                                            ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTTPencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
-
-                                                            // IF ENCODING NOT PRESENT IN HTTP HEADER, READ AGAIN WITH ENCODING FROM HTML META
-                                                            if (endpoint.HTTPencoding == null)
-                                                            {
-                                                                // READ AGAIN WITH ENCODING FROM HTML META [IF PRESENT]
-                                                                if (endpoint.HTMLencoding != null)
-                                                                {
-                                                                    // READ RESPONSE STREAM [HML META ENCODING] AND GET HTML META INFO
-                                                                    ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTMLencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
-                                                                }
-                                                                else
-                                                                {
-                                                                    // SET DEAFULT HTML STREAM ENCODING
-                                                                    endpoint.HTMLencoding = endpoint.HTMLdefaultStreamEncoding;
-                                                                }
-                                                            }
+                                                            locationHeaderValue = Url.Combine(_httpWebResponse.ResponseUri.OriginalString, locationHeaderValue);
                                                         }
+
+                                                        // PREPARE WEBREQUEST
+                                                        HttpWebRequest httpWebRequest_Redirected = PrepareHTTPWebRequest(
+                                                            endpoint,
+                                                            new Uri(locationHeaderValue),
+                                                            checkOptions.HttpRequestTimeout,
+                                                            checkOptions.AllowAutoRedirect,
+                                                            checkOptions.RemoveUrlParameters,
+                                                            _httpWebResponse.Cookies);
+
+                                                        autoRedirect_Followed = true;
+
+                                                        // GET RESPONSE FROM 'LOCATION'
+                                                        httpWebResponse = GetHTTPWebResponse(httpWebRequest_Redirected, 3);
                                                     }
-                                                }
-                                            }
-                                        }
-                                        catch (WebException webException)
-                                        {
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
-
-                                            httpWebResponse = webException.Response as HttpWebResponse;
-
-                                            if (httpWebResponse != null)
-                                            {
-                                            try
-                                            {
-                                                // RESPONSE CODE
-                                                endpoint.ResponseCode = ((int)httpWebResponse.StatusCode).ToString();
-
-                                                // STATUS MESSAGE
-                                                if (!string.IsNullOrEmpty(httpWebResponse.StatusDescription))
-                                                {
-                                                    // STATUS DESCRIPTION
-                                                    endpoint.ResponseMessage = httpWebResponse.StatusDescription;
-
-                                                    // ERROR MESSAGE
-                                                    if (!webException.Message.Contains(endpoint.ResponseCode))
+                                                    else
                                                     {
-                                                        endpoint.ResponseMessage += " -> " + webException.Message;
+                                                        throw;
                                                     }
                                                 }
-                                                else
-                                                {
-                                                    // STATUS CODE [STRING]
-                                                    endpoint.ResponseMessage = httpWebResponse.StatusCode.ToString();
 
-                                                    // ERROR MESSAGE
-                                                    if (!webException.Message.Contains(endpoint.ResponseCode))
-                                                    {
-                                                        endpoint.ResponseMessage += " -> " + webException.Message;
-                                                    }
-                                                }
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
 
                                                 // GET RESPONSE HEADERS
                                                 GetHTTPWebHeaders(endpoint.HTTPResponseHeaders.PropertyItem, httpWebResponse.Headers);
@@ -1027,384 +841,571 @@ namespace EndpointChecker
                                                 // GET SSL INFO
                                                 GetSSLCertificateInfo(httpWebRequest, endpoint);
 
-                                                // CLOUDFLARE BOT-PROTECTION DETECTION
-                                                // CF-RAY header is present on all Cloudflare-proxied responses.
-                                                // A 403/429/503 with CF headers means the endpoint exists but is
-                                                // behind a security challenge that cannot be solved automatically.
-                                                if (IsCloudflareProtected(httpWebResponse))
-                                                {
-                                                    string cfRay = httpWebResponse.Headers["CF-RAY"];
-                                                    endpoint.ResponseMessage +=
-                                                        " [Cloudflare Bot Protection" +
-                                                        (!string.IsNullOrEmpty(cfRay) ? " | CF-RAY: " + cfRay : string.Empty) +
-                                                        "]";
+                                                responseURI = httpWebResponse.ResponseUri;
+                                                endpoint.Port = responseURI.Port.ToString();
+                                                endpoint.Protocol = responseURI.Scheme.ToUpper();
+                                                endpoint.ResponseCode = ((int)httpWebResponse.StatusCode).ToString();
 
-                                                    // ATTEMPT BYPASS VIA CONFIGURED METHOD
-                                                    CloudflareBypassMethod cfBypassMethod =
-                                                        (CloudflareBypassMethod)Settings.Default.Config_CloudflareBypass_Method;
-                                                    if (cfBypassMethod != CloudflareBypassMethod.Disabled)
+                                                // SERVER IDENTIFICATION
+                                                if (!string.IsNullOrEmpty(httpWebResponse.Server))
+                                                {
+                                                    endpoint.ServerID = Regex.Replace(httpWebResponse.Server, "<.*?>", string.Empty);
+                                                }
+
+                                                // STATUS MESSAGE
+                                                if (!string.IsNullOrEmpty(httpWebResponse.StatusDescription))
+                                                {
+                                                    // STATUS DESCRIPTION
+                                                    endpoint.ResponseMessage = httpWebResponse.StatusDescription;
+                                                }
+                                                else
+                                                {
+                                                    // STATUS CODE [STRING]
+                                                    endpoint.ResponseMessage = httpWebResponse.StatusCode.ToString();
+                                                }
+
+                                                // GET AUTO REDIRECTS COUNT
+                                                if (checkOptions.AllowAutoRedirect)
+                                                {
+                                                    FieldInfo fieldInfo = httpWebRequest.GetType().GetField("_AutoRedirects", BindingFlags.NonPublic | BindingFlags.Instance);
+                                                    // _AutoRedirects was removed in .NET 10; guard against null fieldInfo
+                                                    int httpAutoRedirects = fieldInfo != null ? (int)fieldInfo.GetValue(httpWebRequest) : 0;
+                                                    endpoint.HTTPautoRedirects = httpAutoRedirects.ToString();
+
+                                                    // CHECK AUTO REDIRECT URL [COMPARE REQUEST AND RESPONSE ENDPOINT URIs]
+                                                    if (endpointURI.Scheme != responseURI.Scheme ||
+                                                        endpointURI.Port != responseURI.Port ||
+                                                        endpointURI.Host != responseURI.Host ||
+                                                        autoRedirect_Followed)
                                                     {
-                                                        try
+                                                        endpoint.ResponseMessage += " (Redirected from \"" + endpointURI.OriginalString + "\")";
+                                                    }
+                                                }
+
+                                                // GET 'CONTENT TYPE' META VALUE FROM RESPONSE HEADER
+                                                endpoint.HTTPcontentType = GetContentType(httpWebResponse.ContentType);
+
+                                                // GET 'EXPIRES' META VALUE FROM RESPONSE HEADER
+                                                DateTime _httpExpiresDT = DateTime.MinValue;
+                                                if (!string.IsNullOrEmpty(httpWebResponse.Headers["Expires"]) &&
+                                                    TryParseHttpDate(httpWebResponse.Headers["Expires"], out _httpExpiresDT) &&
+                                                    _httpExpiresDT > DateTime.MinValue)
+                                                {
+                                                    endpoint.HTTPexpires = _httpExpiresDT.ToString("dd.MM.yyyy HH:mm");
+                                                }
+
+                                                // GET 'ETAG' META VALUE FROM RESPONSE HEADER
+                                                if (!string.IsNullOrEmpty(httpWebResponse.Headers["ETag"]))
+                                                {
+                                                    endpoint.HTTPetag = httpWebResponse.Headers["ETag"]
+                                                        .ToString()
+                                                        .TrimStart()
+                                                        .TrimEnd()
+                                                        .TrimStart('"')
+                                                        .TrimEnd('"');
+                                                }
+
+                                                // GET CONTENT Length FROM RESPONSE HEADER
+                                                long contentLength = httpWebResponse.ContentLength;
+
+                                                if (!string.IsNullOrEmpty(httpWebResponse.Headers["Content-Length"]))
+                                                {
+                                                    long.TryParse(httpWebResponse.Headers["Content-Length"], out contentLength);
+                                                }
+
+                                                GetWebResponseContentLengthString(endpoint, contentLength);
+
+                                                // TRY TO GET HEADER ENCODING FROM RESPONSE HEADER
+                                                endpoint.HTTPencoding = GetEncoding(httpWebResponse.ContentType);
+
+                                                if (checkOptions.SaveResponse || checkOptions.ResolvePageMetaInfo)
+                                                {
+                                                    // GET RESPONSE STREAM
+                                                    using (BinaryReader httpWebResponseBinaryReader = new BinaryReader(httpWebResponse.GetResponseStream()))
+                                                    {
+                                                        MemoryStream httpWebResponseMemoryStream = new MemoryStream();
+
+                                                        byte[] httpWebResponseByteArray;
+                                                        byte[] httpWebResponseBuffer = httpWebResponseBinaryReader.ReadBytes(1024);
+                                                        while (httpWebResponseBuffer.Length > 0 && httpWebResponseMemoryStream.Length < (http_SaveResponse_MaxLength_Bytes + 1024))
                                                         {
-                                                            CloudflareBypassResult cfBypassResult =
-                                                                CloudflareBypassChecker.Check(
-                                                                    endpoint.ResponseAddress ?? endpoint.Address,
-                                                                    cfBypassMethod,
-                                                                    Settings.Default.Config_FlareSolverr_URL);
-                                                            if (cfBypassResult != null && cfBypassResult.Success)
-                                                            {
-                                                                endpoint.ResponseCode = cfBypassResult.StatusCode.ToString();
-                                                                endpoint.ResponseMessage = cfBypassResult.StatusMessage;
-                                                            }
-                                                            else if (cfBypassResult != null)
-                                                            {
-                                                                endpoint.ResponseMessage +=
-                                                                    " | Bypass(" + cfBypassResult.MethodUsed + "): " +
-                                                                    cfBypassResult.StatusMessage;
-                                                            }
+                                                            httpWebResponseMemoryStream.Write(httpWebResponseBuffer, 0, httpWebResponseBuffer.Length);
+                                                            httpWebResponseBuffer = httpWebResponseBinaryReader.ReadBytes(1024);
                                                         }
-                                                        catch (Exception bypassEx)
+
+                                                        httpWebResponseByteArray = new byte[(int)httpWebResponseMemoryStream.Length];
+                                                        httpWebResponseMemoryStream.Position = 0;
+                                                        httpWebResponseMemoryStream.Read(httpWebResponseByteArray, 0, httpWebResponseByteArray.Length);
+
+                                                        // GET CONTENT Length FROM FULL RESPONSE
+                                                        contentLength = httpWebResponseMemoryStream.Length;
+                                                        GetWebResponseContentLengthString(endpoint, contentLength);
+
+                                                        if (checkOptions.SaveResponse &&
+                                                            !string.IsNullOrEmpty(endpoint.HTTPcontentType) &&
+                                                            CheckWebResponseContentLength(endpoint, httpWebResponse, contentLength))
                                                         {
-                                                            endpoint.ResponseMessage += " | Bypass error: " + bypassEx.Message;
+                                                            // GET FILE EXTENSION BY CONTENT TYPE
+                                                            string fileExtension = GetFileExtensionByContentType(endpoint.HTTPcontentType);
+
+                                                            // SAVE RESPONSE TO FILE
+                                                            SaveWebResponseStream(
+                                                                                  startDT_List,
+                                                                                  endpoint.Name,
+                                                                                  httpWebResponseByteArray,
+                                                                                  fileExtension);
+                                                        }
+
+                                                        if (endpoint.HTTPcontentType == "text/html")
+                                                        {
+                                                            // GET HTML METADATA
+                                                            if (checkOptions.ResolvePageMetaInfo)
+                                                            {
+                                                                // READ RESPONSE STREAM [HTTP HEADER ENCODING] AND GET HTML META INFO
+                                                                ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTTPencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
+
+                                                                // IF ENCODING NOT PRESENT IN HTTP HEADER, READ AGAIN WITH ENCODING FROM HTML META
+                                                                if (endpoint.HTTPencoding == null)
+                                                                {
+                                                                    // READ AGAIN WITH ENCODING FROM HTML META [IF PRESENT]
+                                                                    if (endpoint.HTMLencoding != null)
+                                                                    {
+                                                                        // READ RESPONSE STREAM [HML META ENCODING] AND GET HTML META INFO
+                                                                        ResolvePageMetaInfo(ReadHTTPResponseStream(httpWebResponseMemoryStream, endpoint.HTMLencoding), endpoint, responseURI, checkOptions.ResolvePageLinks);
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        // SET DEAFULT HTML STREAM ENCODING
+                                                                        endpoint.HTMLencoding = endpoint.HTMLdefaultStreamEncoding;
+                                                                    }
+                                                                }
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
-                                            catch (Exception responseEx)
+                                            catch (WebException webException)
                                             {
-                                                // Any unexpected exception inside the WebException handler
-                                                // (e.g. reflection, SSL cert reading) marks the endpoint as error
-                                                // instead of crashing the whole scan.
-                                                endpoint.ResponseCode = status_Error;
-                                                endpoint.ResponseMessage =
-                                                    responseEx.GetType().Name.Replace("Exception", string.Empty) +
-                                                    " -> " + responseEx.Message;
-                                            }
-                                            }
-                                            else
-                                            {
-                                                // EXCEPTION CODE
-                                                endpoint.ResponseCode = status_Error;
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
 
-                                                // EXCEPTION STATUS
-                                                endpoint.ResponseMessage = webException.Status.ToString();
-                                                endpoint.ResponseMessage += " -> " + webException.Message;
+                                                httpWebResponse = webException.Response as HttpWebResponse;
 
-                                                // Walk the full inner exception chain to expose the root cause.
-                                                // In .NET 10, WebException wraps HttpRequestException wraps
-                                                // AuthenticationException/IOException — one level isn't enough.
-                                                Exception innerEx = webException.InnerException;
-                                                while (innerEx != null)
+                                                if (httpWebResponse != null)
                                                 {
-                                                    if (!string.IsNullOrEmpty(innerEx.Message) &&
-                                                        !endpoint.ResponseMessage.Contains(innerEx.Message))
-                                                        endpoint.ResponseMessage += " -> " + innerEx.Message;
-                                                    innerEx = innerEx.InnerException;
+                                                    try
+                                                    {
+                                                        // RESPONSE CODE
+                                                        endpoint.ResponseCode = ((int)httpWebResponse.StatusCode).ToString();
+
+                                                        // STATUS MESSAGE
+                                                        if (!string.IsNullOrEmpty(httpWebResponse.StatusDescription))
+                                                        {
+                                                            // STATUS DESCRIPTION
+                                                            endpoint.ResponseMessage = httpWebResponse.StatusDescription;
+
+                                                            // ERROR MESSAGE
+                                                            if (!webException.Message.Contains(endpoint.ResponseCode))
+                                                            {
+                                                                endpoint.ResponseMessage += " -> " + webException.Message;
+                                                            }
+                                                        }
+                                                        else
+                                                        {
+                                                            // STATUS CODE [STRING]
+                                                            endpoint.ResponseMessage = httpWebResponse.StatusCode.ToString();
+
+                                                            // ERROR MESSAGE
+                                                            if (!webException.Message.Contains(endpoint.ResponseCode))
+                                                            {
+                                                                endpoint.ResponseMessage += " -> " + webException.Message;
+                                                            }
+                                                        }
+
+                                                        // GET RESPONSE HEADERS
+                                                        GetHTTPWebHeaders(endpoint.HTTPResponseHeaders.PropertyItem, httpWebResponse.Headers);
+
+                                                        // GET SSL INFO
+                                                        GetSSLCertificateInfo(httpWebRequest, endpoint);
+
+                                                        // CLOUDFLARE BOT-PROTECTION DETECTION
+                                                        // CF-RAY header is present on all Cloudflare-proxied responses.
+                                                        // A 403/429/503 with CF headers means the endpoint exists but is
+                                                        // behind a security challenge that cannot be solved automatically.
+                                                        if (IsCloudflareProtected(httpWebResponse))
+                                                        {
+                                                            string cfRay = httpWebResponse.Headers["CF-RAY"];
+                                                            endpoint.ResponseMessage +=
+                                                                " [Cloudflare Bot Protection" +
+                                                                (!string.IsNullOrEmpty(cfRay) ? " | CF-RAY: " + cfRay : string.Empty) +
+                                                                "]";
+
+                                                            // ATTEMPT BYPASS VIA CONFIGURED METHOD
+                                                            CloudflareBypassMethod cfBypassMethod =
+                                                                (CloudflareBypassMethod)Settings.Default.Config_CloudflareBypass_Method;
+                                                            if (cfBypassMethod != CloudflareBypassMethod.Disabled)
+                                                            {
+                                                                try
+                                                                {
+                                                                    CloudflareBypassResult cfBypassResult =
+                                                                        CloudflareBypassChecker.Check(
+                                                                            endpoint.ResponseAddress ?? endpoint.Address,
+                                                                            cfBypassMethod,
+                                                                            Settings.Default.Config_FlareSolverr_URL);
+                                                                    if (cfBypassResult != null && cfBypassResult.Success)
+                                                                    {
+                                                                        endpoint.ResponseCode = cfBypassResult.StatusCode.ToString();
+                                                                        endpoint.ResponseMessage = cfBypassResult.StatusMessage;
+                                                                    }
+                                                                    else if (cfBypassResult != null)
+                                                                    {
+                                                                        endpoint.ResponseMessage +=
+                                                                            " | Bypass(" + cfBypassResult.MethodUsed + "): " +
+                                                                            cfBypassResult.StatusMessage;
+                                                                    }
+                                                                }
+                                                                catch (Exception bypassEx)
+                                                                {
+                                                                    endpoint.ResponseMessage += " | Bypass error: " + bypassEx.Message;
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    catch (Exception responseEx)
+                                                    {
+                                                        // Any unexpected exception inside the WebException handler
+                                                        // (e.g. reflection, SSL cert reading) marks the endpoint as error
+                                                        // instead of crashing the whole scan.
+                                                        endpoint.ResponseCode = status_Error;
+                                                        endpoint.ResponseMessage =
+                                                            responseEx.GetType().Name.Replace("Exception", string.Empty) +
+                                                            " -> " + responseEx.Message;
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    // EXCEPTION CODE
+                                                    endpoint.ResponseCode = status_Error;
+
+                                                    // EXCEPTION STATUS
+                                                    endpoint.ResponseMessage = webException.Status.ToString();
+                                                    endpoint.ResponseMessage += " -> " + webException.Message;
+
+                                                    // Walk the full inner exception chain to expose the root cause.
+                                                    // In .NET 10, WebException wraps HttpRequestException wraps
+                                                    // AuthenticationException/IOException — one level isn't enough.
+                                                    Exception innerEx = webException.InnerException;
+                                                    while (innerEx != null)
+                                                    {
+                                                        if (!string.IsNullOrEmpty(innerEx.Message) &&
+                                                            !endpoint.ResponseMessage.Contains(innerEx.Message))
+                                                            endpoint.ResponseMessage += " -> " + innerEx.Message;
+                                                        innerEx = innerEx.InnerException;
+                                                    }
+                                                }
+                                            }
+                                            catch (Exception exception)
+                                            {
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
+
+                                                // CODE
+                                                endpoint.ResponseCode = status_Error;
+
+                                                // EXCEPTION TYPE
+                                                endpoint.ResponseMessage = exception.GetType().Name.Replace("Exception", string.Empty);
+
+                                                // MESSAGE
+                                                endpoint.ResponseMessage += " -> " + exception.Message;
+
+                                                // INNER EXCEPTION MESSAGE
+                                                if (exception.InnerException != null &&
+                                                    !string.IsNullOrEmpty(exception.InnerException.Message) &&
+                                                    !endpoint.ResponseMessage.Contains(exception.InnerException.Message))
+                                                {
+                                                    endpoint.ResponseMessage += " -> " + exception.InnerException.Message;
+                                                }
+                                            }
+                                            finally
+                                            {
+                                                if (httpWebResponse != null)
+                                                {
+                                                    // CLOSE
+                                                    httpWebResponse.Close();
                                                 }
                                             }
                                         }
-                                        catch (Exception exception)
+                                        else if (validationMethod == ValidationMethod.Protocol &&
+                                                 !BW_GetStatus.CancellationPending &&
+                                                 endpoint.Protocol.ToLower() == Uri.UriSchemeFtp)
                                         {
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
+                                            // FTP PROTOCOL SCHEME
+                                            FtpWebRequest ftpWebRequest;
+                                            FtpWebResponse ftpWebResponse = null;
 
-                                            // CODE
-                                            endpoint.ResponseCode = status_Error;
-
-                                            // EXCEPTION TYPE
-                                            endpoint.ResponseMessage = exception.GetType().Name.Replace("Exception", string.Empty);
-
-                                            // MESSAGE
-                                            endpoint.ResponseMessage += " -> " + exception.Message;
-
-                                            // INNER EXCEPTION MESSAGE
-                                            if (exception.InnerException != null &&
-                                                !string.IsNullOrEmpty(exception.InnerException.Message) &&
-                                                !endpoint.ResponseMessage.Contains(exception.InnerException.Message))
-                                            {
-                                                endpoint.ResponseMessage += " -> " + exception.InnerException.Message;
-                                            }
-                                        }
-                                        finally
-                                        {
-                                            if (httpWebResponse != null)
-                                            {
-                                                // CLOSE
-                                                httpWebResponse.Close();
-                                            }
-                                        }
-                                    }
-                                    else if (validationMethod == ValidationMethod.Protocol &&
-                                             !BW_GetStatus.CancellationPending &&
-                                             endpoint.Protocol.ToLower() == Uri.UriSchemeFtp)
-                                    {
-                                        // FTP PROTOCOL SCHEME
-                                        FtpWebRequest ftpWebRequest;
-                                        FtpWebResponse ftpWebResponse = null;
-
-                                        try
-                                        {
-                                            // CREATE REQUEST
-                                            ftpWebRequest = (FtpWebRequest)WebRequest.Create(endpointURI.OriginalString);
-                                            ftpWebRequest.Method = WebRequestMethods.Ftp.PrintWorkingDirectory;
-                                            ftpWebRequest.Timeout = checkOptions.FtpRequestTimeout;
-                                            ftpWebRequest.ReadWriteTimeout = checkOptions.FtpRequestTimeout;
-                                            ftpWebRequest.UsePassive = false;
-                                            ftpWebRequest.UseBinary = false;
-                                            ftpWebRequest.KeepAlive = false;
-                                            ftpWebRequest.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
-                                            ftpWebRequest.Proxy = null;
-
-                                            if (endpoint.LoginName == status_NotAvailable ||
-                                                endpoint.LoginPass == status_NotAvailable)
-                                            {
-                                                // GET DEFAULT CREDENTIALS FROM URI [USERNAME]
-                                                endpoint.LoginName = ftpWebRequest.Credentials.GetCredential(endpointURI, string.Empty).UserName;
-                                                endpoint.LoginPass = anonymousFTPPassword;
-                                            }
-
-                                            // SET CREDENTIALS
-                                            ftpWebRequest.Credentials = new NetworkCredential(endpoint.LoginName, endpoint.LoginPass);
-
-                                            // START STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Start();
-
-                                            // GET RESPONSE
-                                            ftpWebResponse = (FtpWebResponse)ftpWebRequest.GetResponse();
-                                            responseURI = ftpWebResponse.ResponseUri;
-                                            endpoint.Port = responseURI.Port.ToString();
-                                            endpoint.Protocol = responseURI.Scheme.ToUpper();
-
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
-
-                                            // GET STATUS CODE AND MESSAGE
-                                            FTPWebResponseStatusMessage(ftpWebResponse, null, endpoint);
-                                        }
-                                        catch (WebException webException)
-                                        {
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
-
-                                            // GET STATUS CODE AND MESSAGE
-                                            FTPWebResponseStatusMessage(null, webException, endpoint);
-                                        }
-                                        catch (Exception exception)
-                                        {
-                                            // STOP STOPWATCH FOR ITEM CHECK DURATION
-                                            sw_ItemProgress.Stop();
-
-                                            // CODE
-                                            endpoint.ResponseCode = status_Error;
-
-                                            // EXCEPTION TYPE
-                                            endpoint.ResponseMessage = exception.GetType().Name.Replace("Exception", string.Empty);
-
-                                            // EXCEPTION MESSAGE
-                                            endpoint.ResponseMessage += " -> " + exception.Message;
-
-                                            // INNER EXCEPTION MESSAGE
-                                            if (exception.InnerException != null &&
-                                                !string.IsNullOrEmpty(exception.InnerException.Message) &&
-                                                !endpoint.ResponseMessage.Contains(exception.InnerException.Message))
-                                            {
-                                                endpoint.ResponseMessage += " -> " + exception.InnerException.Message;
-                                            }
-                                        }
-                                        finally
-                                        {
-                                            if (ftpWebResponse != null)
-                                            {
-                                                // CLOSE
-                                                ftpWebResponse.Close();
-                                            }
-                                        }
-                                    }
-
-                                    // FILL UP 'IP ADDRESS' / 'DNS NAME' [FAST, FROM INPUT, BY REGEX]
-                                    if (Regex.IsMatch(responseURI.Host, @"^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"))
-                                    {
-                                        // IS IP ADDRESS
-                                        endpoint.IPAddress = new string[] { responseURI.Host };
-                                    }
-                                    else
-                                    {
-                                        // IS DNS NAME
-                                        endpoint.DNSName = new string[] { responseURI.Host };
-                                    }
-
-                                    // DECLARE TEMPORARY LISTS
-                                    List<string> endpointIPAddressesStringList = new List<string>();
-                                    List<string> endpointDNSNamesStringList = new List<string>();
-                                    List<string> endpointMACAddressStringList = new List<string>();
-
-                                    // GET ITEM CHECK DURATION TIME [FOR 'EXPORT' PURPOSE]
-                                    if (validationMethod == ValidationMethod.Protocol &&
-                                        !BW_GetStatus.CancellationPending)
-                                    {
-                                        durationTime_Item = sw_ItemProgress.ElapsedMilliseconds.ToString() + " ms";
-                                    }
-
-                                    if (!BW_GetStatus.CancellationPending &&
-                                        checkOptions.ResolveIpAddresses)
-                                    {
-                                        // RESOLVE IP ADDRESS(ES)
-                                        try
-                                        {
-                                            // GET LIST
-                                            IPAddress[] endpoint_IP_Address_List = Dns.GetHostAddresses(responseURI.Host);
-
-                                            // PROCESS LIST
-                                            foreach (IPAddress endpointIPAddress in endpoint_IP_Address_List)
-                                            {
-                                                if (endpointIPAddress.AddressFamily == AddressFamily.InterNetwork)
-                                                {
-                                                    endpointIPAddressesStringList.Add(endpointIPAddress.ToString());
-                                                }
-                                            }
-                                        }
-                                        catch
-                                        {
-                                        }
-                                    }
-
-                                    if (!BW_GetStatus.CancellationPending &&
-                                        checkOptions.ResolveNetworkShares)
-                                    {
-                                        // RESOLVE NETWORK SHARES
-                                        try
-                                        {
-                                            // GET LIST
-                                            List<string> netSharesList = GetNetShares(responseURI.Host);
-
-                                            // PROCESS LIST
-                                            if (netSharesList.Count > 0)
-                                            {
-                                                netSharesList.Sort();
-                                                endpoint.NetworkShare = netSharesList.ToArray();
-                                            }
-                                        }
-                                        catch
-                                        {
-                                        }
-                                    }
-
-                                    if (!BW_GetStatus.CancellationPending &&
-                                        checkOptions.ResolveDnsNames)
-                                    {
-                                        // RESOLVE DNS NAME(S)
-                                        foreach (string _IP_Address in endpointIPAddressesStringList)
-                                        {
                                             try
                                             {
-                                                // GET DNS NAME
-                                                IPHostEntry hostEntry = Dns.GetHostEntry(_IP_Address);
-                                                endpointDNSNamesStringList.Add(hostEntry.HostName);
+                                                // CREATE REQUEST
+                                                ftpWebRequest = (FtpWebRequest)WebRequest.Create(endpointURI.OriginalString);
+                                                ftpWebRequest.Method = WebRequestMethods.Ftp.PrintWorkingDirectory;
+                                                ftpWebRequest.Timeout = checkOptions.FtpRequestTimeout;
+                                                ftpWebRequest.ReadWriteTimeout = checkOptions.FtpRequestTimeout;
+                                                ftpWebRequest.UsePassive = false;
+                                                ftpWebRequest.UseBinary = false;
+                                                ftpWebRequest.KeepAlive = false;
+                                                ftpWebRequest.CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore);
+                                                ftpWebRequest.Proxy = null;
+
+                                                if (endpoint.LoginName == status_NotAvailable ||
+                                                    endpoint.LoginPass == status_NotAvailable)
+                                                {
+                                                    // GET DEFAULT CREDENTIALS FROM URI [USERNAME]
+                                                    endpoint.LoginName = ftpWebRequest.Credentials.GetCredential(endpointURI, string.Empty).UserName;
+                                                    endpoint.LoginPass = anonymousFTPPassword;
+                                                }
+
+                                                // SET CREDENTIALS
+                                                ftpWebRequest.Credentials = new NetworkCredential(endpoint.LoginName, endpoint.LoginPass);
+
+                                                // START STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Start();
+
+                                                // GET RESPONSE
+                                                ftpWebResponse = (FtpWebResponse)ftpWebRequest.GetResponse();
+                                                responseURI = ftpWebResponse.ResponseUri;
+                                                endpoint.Port = responseURI.Port.ToString();
+                                                endpoint.Protocol = responseURI.Scheme.ToUpper();
+
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
+
+                                                // GET STATUS CODE AND MESSAGE
+                                                FTPWebResponseStatusMessage(ftpWebResponse, null, endpoint);
+                                            }
+                                            catch (WebException webException)
+                                            {
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
+
+                                                // GET STATUS CODE AND MESSAGE
+                                                FTPWebResponseStatusMessage(null, webException, endpoint);
+                                            }
+                                            catch (Exception exception)
+                                            {
+                                                // STOP STOPWATCH FOR ITEM CHECK DURATION
+                                                sw_ItemProgress.Stop();
+
+                                                // CODE
+                                                endpoint.ResponseCode = status_Error;
+
+                                                // EXCEPTION TYPE
+                                                endpoint.ResponseMessage = exception.GetType().Name.Replace("Exception", string.Empty);
+
+                                                // EXCEPTION MESSAGE
+                                                endpoint.ResponseMessage += " -> " + exception.Message;
+
+                                                // INNER EXCEPTION MESSAGE
+                                                if (exception.InnerException != null &&
+                                                    !string.IsNullOrEmpty(exception.InnerException.Message) &&
+                                                    !endpoint.ResponseMessage.Contains(exception.InnerException.Message))
+                                                {
+                                                    endpoint.ResponseMessage += " -> " + exception.InnerException.Message;
+                                                }
+                                            }
+                                            finally
+                                            {
+                                                if (ftpWebResponse != null)
+                                                {
+                                                    // CLOSE
+                                                    ftpWebResponse.Close();
+                                                }
+                                            }
+                                        }
+
+                                        // FILL UP 'IP ADDRESS' / 'DNS NAME' [FAST, FROM INPUT, BY REGEX]
+                                        if (Regex.IsMatch(responseURI.Host, @"^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"))
+                                        {
+                                            // IS IP ADDRESS
+                                            endpoint.IPAddress = new string[] { responseURI.Host };
+                                        }
+                                        else
+                                        {
+                                            // IS DNS NAME
+                                            endpoint.DNSName = new string[] { responseURI.Host };
+                                        }
+
+                                        // DECLARE TEMPORARY LISTS
+                                        List<string> endpointIPAddressesStringList = new List<string>();
+                                        List<string> endpointDNSNamesStringList = new List<string>();
+                                        List<string> endpointMACAddressStringList = new List<string>();
+
+                                        // GET ITEM CHECK DURATION TIME [FOR 'EXPORT' PURPOSE]
+                                        if (validationMethod == ValidationMethod.Protocol &&
+                                            !BW_GetStatus.CancellationPending)
+                                        {
+                                            durationTime_Item = sw_ItemProgress.ElapsedMilliseconds.ToString() + " ms";
+                                        }
+
+                                        if (!BW_GetStatus.CancellationPending &&
+                                            checkOptions.ResolveIpAddresses)
+                                        {
+                                            // RESOLVE IP ADDRESS(ES)
+                                            try
+                                            {
+                                                // GET LIST
+                                                IPAddress[] endpoint_IP_Address_List = Dns.GetHostAddresses(responseURI.Host);
+
+                                                // PROCESS LIST
+                                                foreach (IPAddress endpointIPAddress in endpoint_IP_Address_List)
+                                                {
+                                                    if (endpointIPAddress.AddressFamily == AddressFamily.InterNetwork)
+                                                    {
+                                                        endpointIPAddressesStringList.Add(endpointIPAddress.ToString());
+                                                    }
+                                                }
                                             }
                                             catch
                                             {
                                             }
                                         }
-                                    }
 
-                                    if (!BW_GetStatus.CancellationPending &&
-                                        checkOptions.ResolveMacAddresses)
-                                    {
-                                        foreach (string _IP_Address in endpointIPAddressesStringList)
+                                        if (!BW_GetStatus.CancellationPending &&
+                                            checkOptions.ResolveNetworkShares)
                                         {
+                                            // RESOLVE NETWORK SHARES
                                             try
                                             {
-                                                // RESOLVE MAC ADDRESS
-                                                string macAddress = WindowsLookupService.Lookup(IPAddress.Parse(_IP_Address));
+                                                // GET LIST
+                                                List<string> netSharesList = GetNetShares(responseURI.Host);
 
-                                                // IF ENDPOINT IP ADDRESS IS ANY OF 'DNS SERVER OR DEFAULT GATEWAY' IPs
-                                                // OR
-                                                // RESOLVED MAC IS NOT ANY OF 'DNS SERVER OR DEFAULT GATEWAY' MAC ADDRESSes
-                                                if (!string.IsNullOrEmpty(macAddress) &&
-                                                   (!localDNSAndGWMACAddresses.Contains(macAddress) ||
-                                                    localDNSAndGWIPAddresses.Contains(_IP_Address.ToString())))
+                                                // PROCESS LIST
+                                                if (netSharesList.Count > 0)
                                                 {
-                                                    endpointMACAddressStringList.Add(macAddress);
+                                                    netSharesList.Sort();
+                                                    endpoint.NetworkShare = netSharesList.ToArray();
                                                 }
                                             }
                                             catch
                                             {
                                             }
                                         }
-                                    }
 
-                                    if (!BW_GetStatus.CancellationPending &&
-                                        checkOptions.TestPing)
-                                    {
-                                        if (validationMethod == ValidationMethod.Ping)
+                                        if (!BW_GetStatus.CancellationPending &&
+                                            checkOptions.ResolveDnsNames)
                                         {
-                                            endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.PINGCHECK);
-                                        }
-
-                                        // TEST PING
-                                        try
-                                        {
-                                            string pingRoundtripTime = GetPingTime(responseURI.Host, checkOptions.PingTimeout, 1);
-
-                                            if (!string.IsNullOrEmpty(pingRoundtripTime))
+                                            // RESOLVE DNS NAME(S)
+                                            foreach (string _IP_Address in endpointIPAddressesStringList)
                                             {
-                                                endpoint.PingRoundtripTime = pingRoundtripTime;
+                                                try
+                                                {
+                                                    // GET DNS NAME
+                                                    IPHostEntry hostEntry = Dns.GetHostEntry(_IP_Address);
+                                                    endpointDNSNamesStringList.Add(hostEntry.HostName);
+                                                }
+                                                catch
+                                                {
+                                                }
                                             }
                                         }
-                                        catch
+
+                                        if (!BW_GetStatus.CancellationPending &&
+                                            checkOptions.ResolveMacAddresses)
                                         {
+                                            foreach (string _IP_Address in endpointIPAddressesStringList)
+                                            {
+                                                try
+                                                {
+                                                    // RESOLVE MAC ADDRESS
+                                                    string macAddress = WindowsLookupService.Lookup(IPAddress.Parse(_IP_Address));
+
+                                                    // IF ENDPOINT IP ADDRESS IS ANY OF 'DNS SERVER OR DEFAULT GATEWAY' IPs
+                                                    // OR
+                                                    // RESOLVED MAC IS NOT ANY OF 'DNS SERVER OR DEFAULT GATEWAY' MAC ADDRESSes
+                                                    if (!string.IsNullOrEmpty(macAddress) &&
+                                                       (!localDNSAndGWMACAddresses.Contains(macAddress) ||
+                                                        localDNSAndGWIPAddresses.Contains(_IP_Address.ToString())))
+                                                    {
+                                                        endpointMACAddressStringList.Add(macAddress);
+                                                    }
+                                                }
+                                                catch
+                                                {
+                                                }
+                                            }
                                         }
-                                    }
 
-                                    // FILL IP ADDRESS(ES) LIST
-                                    if (endpointIPAddressesStringList.Count > 0)
-                                    {
-                                        endpoint.IPAddress = endpointIPAddressesStringList.ToArray();
-                                    }
+                                        if (!BW_GetStatus.CancellationPending &&
+                                            checkOptions.TestPing)
+                                        {
+                                            if (validationMethod == ValidationMethod.Ping)
+                                            {
+                                                endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.PINGCHECK);
+                                            }
 
-                                    // FILL DNS NAME(S) LIST
-                                    if (endpointDNSNamesStringList.Count > 0)
-                                    {
-                                        endpoint.DNSName = endpointDNSNamesStringList.ToArray();
-                                    }
+                                            // TEST PING
+                                            try
+                                            {
+                                                string pingRoundtripTime = GetPingTime(responseURI.Host, checkOptions.PingTimeout, 1);
 
-                                    // FILL MAC ADDRESS(ES) LIST
-                                    if (endpointMACAddressStringList.Count > 0)
-                                    {
-                                        endpoint.MACAddress = endpointMACAddressStringList.ToArray();
-                                    }
+                                                if (!string.IsNullOrEmpty(pingRoundtripTime))
+                                                {
+                                                    endpoint.PingRoundtripTime = pingRoundtripTime;
+                                                }
+                                            }
+                                            catch
+                                            {
+                                            }
+                                        }
 
+                                        // FILL IP ADDRESS(ES) LIST
+                                        if (endpointIPAddressesStringList.Count > 0)
+                                        {
+                                            endpoint.IPAddress = endpointIPAddressesStringList.ToArray();
+                                        }
+
+                                        // FILL DNS NAME(S) LIST
+                                        if (endpointDNSNamesStringList.Count > 0)
+                                        {
+                                            endpoint.DNSName = endpointDNSNamesStringList.ToArray();
+                                        }
+
+                                        // FILL MAC ADDRESS(ES) LIST
+                                        if (endpointMACAddressStringList.Count > 0)
+                                        {
+                                            endpoint.MACAddress = endpointMACAddressStringList.ToArray();
+                                        }
+
+                                    }
                                 }
-                            }
 
-                            // UPDATE ADDRESSES
-                            endpoint.Address = endpointURI.OriginalString;
-                            endpoint.ResponseAddress = responseURI.AbsoluteUri;
+                                // UPDATE ADDRESSES
+                                endpoint.Address = endpointURI.OriginalString;
+                                endpoint.ResponseAddress = responseURI.AbsoluteUri;
 
-                            // UPDATE RESPONSE TIME
-                            endpoint.ResponseTime = durationTime_Item;
+                                // UPDATE RESPONSE TIME
+                                endpoint.ResponseTime = durationTime_Item;
 
-                            // CHECK 'TERMINATED' STATUS
-                            if (BW_GetStatus.CancellationPending)
-                            {
-                                endpoint.ResponseCode = status_NotAvailable;
-                                endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.TERMINATED);
-                            }
-                            else
-                            {
-                                // UPDATE 'LAST SEEN ONLINE' VALUE
-                                if ((validationMethod == ValidationMethod.Protocol &&
-                                     endpoint.ResponseCode != status_Error &&
-                                     endpoint.ResponseCode != status_NotAvailable) ||
-                                    (validationMethod == ValidationMethod.Ping &&
-                                     endpoint.PingRoundtripTime != status_NotAvailable))
+                                // CHECK 'TERMINATED' STATUS
+                                if (BW_GetStatus.CancellationPending)
                                 {
-                                    endpoint.LastSeenOnline = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                                    endpoint.ResponseCode = status_NotAvailable;
+                                    endpoint.ResponseMessage = GetEnumDescriptionString(EndpointStatus.TERMINATED);
                                 }
-                            }
+                                else
+                                {
+                                    // UPDATE 'LAST SEEN ONLINE' VALUE
+                                    if ((validationMethod == ValidationMethod.Protocol &&
+                                         endpoint.ResponseCode != status_Error &&
+                                         endpoint.ResponseCode != status_NotAvailable) ||
+                                        (validationMethod == ValidationMethod.Ping &&
+                                         endpoint.PingRoundtripTime != status_NotAvailable))
+                                    {
+                                        endpoint.LastSeenOnline = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                                    }
+                                }
 
-                            // ADD UPDATED STATUS DEFINITION TO LIST
-                            updatedEndpointsList.Add(endpoint);
+                                // ADD UPDATED STATUS DEFINITION TO LIST
+                                updatedEndpointsList.Add(endpoint);
                             }
                             catch (Exception lambdaEx)
                             {
@@ -1508,12 +1509,18 @@ namespace EndpointChecker
                     endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Version", ItemValue = sslCert2.Version.ToString() });
                     endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Public Key", ItemValue = sslCert2.GetPublicKeyString() });
 
-                    if (!string.IsNullOrEmpty(sslCert2.SignatureAlgorithm.FriendlyName)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Signature Algorithm", ItemValue = sslCert2.SignatureAlgorithm.FriendlyName }); };
-                    if (!string.IsNullOrEmpty(sslCert2.FriendlyName)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Friendly Name", ItemValue = sslCert2.FriendlyName }); };
-                    if (!string.IsNullOrEmpty(sslCert2.Issuer)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Issuer Name", ItemValue = sslCert2.Issuer }); };
-                    if (!string.IsNullOrEmpty(sslCert2.SerialNumber)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Serial Number", ItemValue = sslCert2.SerialNumber }); };
-                    if (!string.IsNullOrEmpty(sslCert2.Subject)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Subject", ItemValue = sslCert2.Subject }); };
-                    if (!string.IsNullOrEmpty(sslCert2.Thumbprint)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Thumbprint", ItemValue = sslCert2.Thumbprint }); };
+                    if (!string.IsNullOrEmpty(sslCert2.SignatureAlgorithm.FriendlyName)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Signature Algorithm", ItemValue = sslCert2.SignatureAlgorithm.FriendlyName }); }
+                    ;
+                    if (!string.IsNullOrEmpty(sslCert2.FriendlyName)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Friendly Name", ItemValue = sslCert2.FriendlyName }); }
+                    ;
+                    if (!string.IsNullOrEmpty(sslCert2.Issuer)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Issuer Name", ItemValue = sslCert2.Issuer }); }
+                    ;
+                    if (!string.IsNullOrEmpty(sslCert2.SerialNumber)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Serial Number", ItemValue = sslCert2.SerialNumber }); }
+                    ;
+                    if (!string.IsNullOrEmpty(sslCert2.Subject)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Subject", ItemValue = sslCert2.Subject }); }
+                    ;
+                    if (!string.IsNullOrEmpty(sslCert2.Thumbprint)) { endpoint.SSLCertificateProperties.PropertyItem.Add(new Property { ItemName = "Thumbprint", ItemValue = sslCert2.Thumbprint }); }
+                    ;
                 }
                 catch
                 {
@@ -2732,7 +2739,7 @@ namespace EndpointChecker
                 Type t = typeof(NotifyIcon);
                 BindingFlags hidden = BindingFlags.NonPublic | BindingFlags.Instance;
                 // .NET 5+ renamed "text"→"_text" and "added"→"_added"; try new name first
-                FieldInfo textField  = t.GetField("_text",  hidden) ?? t.GetField("text",  hidden);
+                FieldInfo textField = t.GetField("_text", hidden) ?? t.GetField("text", hidden);
                 FieldInfo addedField = t.GetField("_added", hidden) ?? t.GetField("added", hidden);
                 MethodInfo updateMethod = t.GetMethod("UpdateIcon", hidden);
                 if (textField != null)
@@ -3596,7 +3603,7 @@ namespace EndpointChecker
 
         public Color GetForeColorByStatus(string statusCode, string pingTime, string statusMessage)
         {
-            Color muted  = Color.FromArgb( 90, 105, 140);  // dimmed — for disabled/not-checked
+            Color muted = Color.FromArgb(90, 105, 140);  // dimmed — for disabled/not-checked
             Color bright = Color.FromArgb(220, 235, 255);  // off-white — default readable text
 
             if (statusCode == status_NotAvailable)
@@ -4680,7 +4687,7 @@ namespace EndpointChecker
 
             return false;
         }
-                
+
         public static void GetLocalDNSAndGWAddresses(out List<string> localDNSAndGWipAddresses, out List<string> localDNSAndGWmacAddresses)
         {
             localDNSAndGWipAddresses = new List<string>();
@@ -4848,7 +4855,7 @@ namespace EndpointChecker
                             selectedEndpointDefinition.LoginPass);
 
                 WindowState = FormWindowState.Minimized;
-            }            
+            }
         }
 
         public void toolStripMenuItem_HTTP_Click(object sender, EventArgs e)
@@ -4869,7 +4876,7 @@ namespace EndpointChecker
 
                 WindowState = FormWindowState.Minimized;
 
-            }            
+            }
         }
 
         public void toolStripMenuItem_RDP_Click(object sender, EventArgs e)
@@ -4879,7 +4886,7 @@ namespace EndpointChecker
                 ConnectEndpoint_RDP(new Uri(selectedEndpointDefinition.ResponseAddress).Host);
 
                 WindowState = FormWindowState.Minimized;
-            }            
+            }
         }
 
         public void toolStripMenuItem_VNC_Click(object sender, EventArgs e)
@@ -4889,7 +4896,7 @@ namespace EndpointChecker
                 ConnectEndpoint_VNC(new Uri(selectedEndpointDefinition.ResponseAddress).Host);
 
                 WindowState = FormWindowState.Minimized;
-            }            
+            }
         }
 
         public void toolStripMenuItem_SSH_Click(object sender, EventArgs e)
@@ -5656,19 +5663,19 @@ namespace EndpointChecker
         private void ApplyPremiumTheme()
         {
             // ── Palette ──────────────────────────────────────────────────────────
-            Color bg          = Color.FromArgb(  8,  14,  27);
-            Color surface     = Color.FromArgb( 16,  26,  43);
-            Color surfaceAlt  = Color.FromArgb( 23,  36,  61);
-            Color input       = Color.FromArgb( 12,  21,  36);
-            Color accent      = Color.FromArgb( 70, 143, 255);
-            Color accentAlt   = Color.FromArgb( 42,  96, 214);
-            Color success     = Color.FromArgb( 59, 218, 128);
-            Color warning     = Color.FromArgb(255, 183,  67);
-            Color danger      = Color.FromArgb(255,  99, 107);
-            Color textMain    = Color.FromArgb(230, 238, 252);
-            Color textMute    = Color.FromArgb(142, 158, 190);
-            Color menuBg      = Color.FromArgb(  7,  13,  25);
-            Color cardBorder  = Color.FromArgb(55, 77, 122);
+            Color bg = Color.FromArgb(8, 14, 27);
+            Color surface = Color.FromArgb(16, 26, 43);
+            Color surfaceAlt = Color.FromArgb(23, 36, 61);
+            Color input = Color.FromArgb(12, 21, 36);
+            Color accent = Color.FromArgb(70, 143, 255);
+            Color accentAlt = Color.FromArgb(42, 96, 214);
+            Color success = Color.FromArgb(59, 218, 128);
+            Color warning = Color.FromArgb(255, 183, 67);
+            Color danger = Color.FromArgb(255, 99, 107);
+            Color textMain = Color.FromArgb(230, 238, 252);
+            Color textMute = Color.FromArgb(142, 158, 190);
+            Color menuBg = Color.FromArgb(7, 13, 25);
+            Color cardBorder = Color.FromArgb(55, 77, 122);
 
             // Form
             BackColor = bg;
@@ -5677,7 +5684,7 @@ namespace EndpointChecker
             // Menu strip
             MainMenuStrip.BackColor = menuBg;
             MainMenuStrip.ForeColor = textMain;
-            MainMenuStrip.Renderer  = new DarkMenuStripRenderer();
+            MainMenuStrip.Renderer = new DarkMenuStripRenderer();
             MainMenuStrip.Font = new Font("Segoe UI Semibold", 9F, FontStyle.Bold, GraphicsUnit.Point);
             MainMenuStrip.ImageScalingSize = new Size(18, 18);
             MainMenuStrip.Padding = new Padding(8, 5, 8, 5);
@@ -5832,7 +5839,7 @@ namespace EndpointChecker
             {
                 cms.BackColor = menuBg;
                 cms.ForeColor = textMain;
-                cms.Renderer  = new DarkMenuStripRenderer();
+                cms.Renderer = new DarkMenuStripRenderer();
                 cms.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
                 cms.ImageScalingSize = new Size(18, 18);
                 foreach (ToolStripItem item in cms.Items)
@@ -7137,10 +7144,10 @@ namespace EndpointChecker
 
         public static void ApplyDarkTheme(Control root)
         {
-            Color bg       = Color.FromArgb( 10,  16,  31);
-            Color surface  = Color.FromArgb( 18,  27,  45);
-            Color input    = Color.FromArgb( 14,  23,  39);
-            Color accent   = Color.FromArgb( 74, 132, 255);
+            Color bg = Color.FromArgb(10, 16, 31);
+            Color surface = Color.FromArgb(18, 27, 45);
+            Color input = Color.FromArgb(14, 23, 39);
+            Color accent = Color.FromArgb(74, 132, 255);
             Color textMain = Color.FromArgb(224, 233, 248);
 
             root.BackColor = bg;
@@ -7225,23 +7232,23 @@ namespace EndpointChecker
 
         private sealed class DarkMenuColorTable : ProfessionalColorTable
         {
-            private static readonly Color _dark   = Color.FromArgb(12,  14,  30);
-            private static readonly Color _hover  = Color.FromArgb(55,  75, 145);
-            private static readonly Color _border = Color.FromArgb(65,  90, 170);
+            private static readonly Color _dark = Color.FromArgb(12, 14, 30);
+            private static readonly Color _hover = Color.FromArgb(55, 75, 145);
+            private static readonly Color _border = Color.FromArgb(65, 90, 170);
 
-            public override Color MenuStripGradientBegin        => _dark;
-            public override Color MenuStripGradientEnd          => _dark;
+            public override Color MenuStripGradientBegin => _dark;
+            public override Color MenuStripGradientEnd => _dark;
             public override Color MenuItemSelectedGradientBegin => _hover;
-            public override Color MenuItemSelectedGradientEnd   => _hover;
-            public override Color MenuItemSelected              => _hover;
-            public override Color MenuItemBorder                => _border;
-            public override Color MenuBorder                    => _border;
-            public override Color ToolStripDropDownBackground   => _dark;
-            public override Color ImageMarginGradientBegin      => _dark;
-            public override Color ImageMarginGradientMiddle     => _dark;
-            public override Color ImageMarginGradientEnd        => _dark;
-            public override Color SeparatorDark                 => _border;
-            public override Color SeparatorLight                => _hover;
+            public override Color MenuItemSelectedGradientEnd => _hover;
+            public override Color MenuItemSelected => _hover;
+            public override Color MenuItemBorder => _border;
+            public override Color MenuBorder => _border;
+            public override Color ToolStripDropDownBackground => _dark;
+            public override Color ImageMarginGradientBegin => _dark;
+            public override Color ImageMarginGradientMiddle => _dark;
+            public override Color ImageMarginGradientEnd => _dark;
+            public override Color SeparatorDark => _border;
+            public override Color SeparatorLight => _hover;
         }
 
         public void btn_LoadList_Click(object sender, EventArgs e)
@@ -7259,32 +7266,32 @@ namespace EndpointChecker
 
     public sealed class PremiumProgressBar : Panel
     {
-        private int   _value   = 0;
-        private int   _maximum = 100;
-        private float _sweep   = -0.3f;
+        private int _value = 0;
+        private int _maximum = 100;
+        private float _sweep = -0.3f;
         private readonly System.Windows.Forms.Timer _anim;
 
-        private static readonly Color ColBg     = Color.FromArgb( 15,  18,  38);
-        private static readonly Color ColFillA  = Color.FromArgb( 38,  65, 175);
-        private static readonly Color ColFillB  = Color.FromArgb( 88, 126, 232);
-        private static readonly Color ColBorder = Color.FromArgb( 55,  85, 200);
+        private static readonly Color ColBg = Color.FromArgb(15, 18, 38);
+        private static readonly Color ColFillA = Color.FromArgb(38, 65, 175);
+        private static readonly Color ColFillB = Color.FromArgb(88, 126, 232);
+        private static readonly Color ColBorder = Color.FromArgb(55, 85, 200);
 
         public PremiumProgressBar()
         {
             SetStyle(ControlStyles.OptimizedDoubleBuffer |
-                     ControlStyles.AllPaintingInWmPaint  |
-                     ControlStyles.UserPaint             |
+                     ControlStyles.AllPaintingInWmPaint |
+                     ControlStyles.UserPaint |
                      ControlStyles.ResizeRedraw, true);
             BackColor = ColBg;
             _anim = new System.Windows.Forms.Timer { Interval = 16 };
             _anim.Tick += (_, __) => { _sweep += 0.008f; if (_sweep > 1.3f) _sweep = -0.3f; Invalidate(); };
         }
 
-        public int Value   { get => _value;   set { _value   = Math.Clamp(value, 0, _maximum); Invalidate(); } }
+        public int Value { get => _value; set { _value = Math.Clamp(value, 0, _maximum); Invalidate(); } }
         public int Maximum { get => _maximum; set { _maximum = Math.Max(1, value); Invalidate(); } }
 
         public void StartAnimation() { _sweep = -0.3f; _anim.Start(); }
-        public void StopAnimation()  { _anim.Stop(); _value = 0; Invalidate(); }
+        public void StopAnimation() { _anim.Stop(); _value = 0; Invalidate(); }
 
         protected override void OnPaint(PaintEventArgs e)
         {
@@ -7296,7 +7303,7 @@ namespace EndpointChecker
             using (var bg = new SolidBrush(ColBg))
                 g.FillRectangle(bg, ClientRectangle);
 
-            int barH  = Height - 2;
+            int barH = Height - 2;
             int fillW = _maximum > 0
                 ? Math.Max(0, (int)((double)_value / _maximum * (Width - 2)))
                 : 0;
@@ -7330,8 +7337,8 @@ namespace EndpointChecker
                 // Shimmer sweep
                 float cx = 1f + _sweep * fillW;
                 float bw = fillW * 0.20f + 8f;
-                var   pt1 = new System.Drawing.PointF(cx - bw, 0f);
-                var   pt2 = new System.Drawing.PointF(cx + bw, 0f);
+                var pt1 = new System.Drawing.PointF(cx - bw, 0f);
+                var pt2 = new System.Drawing.PointF(cx + bw, 0f);
 
                 try
                 {
@@ -7343,7 +7350,7 @@ namespace EndpointChecker
                         sb.WrapMode = System.Drawing.Drawing2D.WrapMode.Clamp;
                         sb.InterpolationColors = new System.Drawing.Drawing2D.ColorBlend(3)
                         {
-                            Colors    = new[] { Color.FromArgb(  0, 200, 220, 255),
+                            Colors = new[] { Color.FromArgb(  0, 200, 220, 255),
                                                 Color.FromArgb( 60, 200, 220, 255),
                                                 Color.FromArgb(  0, 200, 220, 255) },
                             Positions = new[] { 0f, 0.5f, 1f }

--- a/src/CloudflareBypassChecker.cs
+++ b/src/CloudflareBypassChecker.cs
@@ -10,9 +10,9 @@ namespace EndpointChecker
 {
     public enum CloudflareBypassMethod
     {
-        Disabled     = 0,
+        Disabled = 0,
         FlareSolverr = 1,
-        Playwright   = 2
+        Playwright = 2
     }
 
     public class CloudflareBypassResult

--- a/src/ConfigDialog.cs
+++ b/src/ConfigDialog.cs
@@ -63,13 +63,13 @@ namespace EndpointChecker
 
         private void BuildUI()
         {
-            Text            = "Configuration";
-            Size            = new Size(600, 510);
+            Text = "Configuration";
+            Size = new Size(600, 510);
             FormBorderStyle = FormBorderStyle.FixedDialog;
-            MaximizeBox     = false;
-            MinimizeBox     = false;
-            StartPosition   = FormStartPosition.CenterParent;
-            Font            = new Font("Segoe UI", 9f);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Font = new Font("Segoe UI", 9f);
 
             var tabs = new TabControl { Dock = DockStyle.Fill };
             tabs.TabPages.Add(BuildRefreshTab());
@@ -79,7 +79,7 @@ namespace EndpointChecker
             tabs.TabPages.Add(BuildToolsTab());
 
             var footer = new Panel { Dock = DockStyle.Bottom, Height = 46 };
-            var btnOk     = new Button { Text = "OK",     DialogResult = DialogResult.OK,     Size = new Size(88, 28), Location = new Point(392, 9) };
+            var btnOk = new Button { Text = "OK", DialogResult = DialogResult.OK, Size = new Size(88, 28), Location = new Point(392, 9) };
             var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Size = new Size(88, 28), Location = new Point(488, 9) };
             btnOk.Click += BtnOk_Click;
             footer.Controls.AddRange(new Control[] { btnOk, btnCancel });
@@ -95,18 +95,21 @@ namespace EndpointChecker
             var tab = new TabPage("Refresh & Notifications");
             int y = 16;
 
-            cb_AutoRefresh       = AddCheck(tab, "Enable automatic refresh",        ref y);
-            cb_ContinuousRefresh = AddCheck(tab, "Continuous refresh (loop)",       ref y);
-            cb_AutoAdjustInterval= AddCheck(tab, "Auto-adjust refresh interval",    ref y);
-            cb_ScanOnStartup     = AddCheck(tab, "Scan on startup",                 ref y);
-            cb_TrayNotify        = AddCheck(tab, "Tray balloon notification on error", ref y);
+            cb_AutoRefresh = AddCheck(tab, "Enable automatic refresh", ref y);
+            cb_ContinuousRefresh = AddCheck(tab, "Continuous refresh (loop)", ref y);
+            cb_AutoAdjustInterval = AddCheck(tab, "Auto-adjust refresh interval", ref y);
+            cb_ScanOnStartup = AddCheck(tab, "Scan on startup", ref y);
+            cb_TrayNotify = AddCheck(tab, "Tray balloon notification on error", ref y);
 
             y += 10;
             AddLabel(tab, "Refresh interval (minutes):", 14, y);
             num_RefreshInterval = new NumericUpDown
             {
-                Location = new Point(230, y - 2), Width = 80,
-                Minimum = 0, Maximum = 1440, DecimalPlaces = 0
+                Location = new Point(230, y - 2),
+                Width = 80,
+                Minimum = 0,
+                Maximum = 1440,
+                DecimalPlaces = 0
             };
             tab.Controls.Add(num_RefreshInterval);
 
@@ -121,7 +124,8 @@ namespace EndpointChecker
             AddLabel(tab, "Validation method:", 14, y);
             cmb_ValidationMethod = new ComboBox
             {
-                Location = new Point(190, y - 2), Width = 180,
+                Location = new Point(190, y - 2),
+                Width = 180,
                 DropDownStyle = ComboBoxStyle.DropDownList
             };
             cmb_ValidationMethod.Items.Add("Protocol");
@@ -129,9 +133,9 @@ namespace EndpointChecker
             tab.Controls.Add(cmb_ValidationMethod);
             y += 32;
 
-            cb_TestPing      = AddCheck(tab, "Test Ping (ICMP)", ref y);
+            cb_TestPing = AddCheck(tab, "Test Ping (ICMP)", ref y);
             cb_AllowRedirect = AddCheck(tab, "Allow automatic HTTP redirects", ref y);
-            cb_ValidateSSL   = AddCheck(tab, "Validate SSL certificate", ref y);
+            cb_ValidateSSL = AddCheck(tab, "Validate SSL certificate", ref y);
             y += 10;
 
             AddLabel(tab, "Ping timeout (seconds):", 14, y);
@@ -161,14 +165,14 @@ namespace EndpointChecker
             var tab = new TabPage("Resolution");
             int y = 16;
 
-            cb_ResolveDns    = AddCheck(tab, "Resolve DNS names",             ref y);
-            cb_ResolveIp     = AddCheck(tab, "Resolve IP addresses",           ref y);
-            cb_ResolveMac    = AddCheck(tab, "Resolve MAC addresses",          ref y);
-            cb_ResolveShares = AddCheck(tab, "Resolve network shares",         ref y);
-            cb_PageMetaInfo  = AddCheck(tab, "Resolve page meta info (HTML)",  ref y);
-            cb_RemoveUrlParams = AddCheck(tab, "Remove URL parameters",        ref y);
-            cb_PageLinks     = AddCheck(tab, "Resolve page links (HTML)",      ref y);
-            cb_SaveResponse  = AddCheck(tab, "Save HTTP response to disk",     ref y);
+            cb_ResolveDns = AddCheck(tab, "Resolve DNS names", ref y);
+            cb_ResolveIp = AddCheck(tab, "Resolve IP addresses", ref y);
+            cb_ResolveMac = AddCheck(tab, "Resolve MAC addresses", ref y);
+            cb_ResolveShares = AddCheck(tab, "Resolve network shares", ref y);
+            cb_PageMetaInfo = AddCheck(tab, "Resolve page meta info (HTML)", ref y);
+            cb_RemoveUrlParams = AddCheck(tab, "Remove URL parameters", ref y);
+            cb_PageLinks = AddCheck(tab, "Resolve page links (HTML)", ref y);
+            cb_SaveResponse = AddCheck(tab, "Save HTTP response to disk", ref y);
 
             return tab;
         }
@@ -179,9 +183,9 @@ namespace EndpointChecker
             int y = 16;
 
             cb_ExportXlsx = AddCheck(tab, "Export to XLSX (Excel)", ref y);
-            cb_ExportJson = AddCheck(tab, "Export to JSON",          ref y);
-            cb_ExportXml  = AddCheck(tab, "Export to XML",           ref y);
-            cb_ExportHtml = AddCheck(tab, "Export to HTML",          ref y);
+            cb_ExportJson = AddCheck(tab, "Export to JSON", ref y);
+            cb_ExportXml = AddCheck(tab, "Export to XML", ref y);
+            cb_ExportHtml = AddCheck(tab, "Export to HTML", ref y);
             y += 10;
 
             AddLabel(tab, "Export directory:", 14, y);
@@ -240,41 +244,41 @@ namespace EndpointChecker
         {
             var s = Settings.Default;
 
-            cb_AutoRefresh.Checked        = s.Config_EnableAutomaticRefresh;
-            cb_ContinuousRefresh.Checked  = s.Config_EnableContinuousRefresh;
+            cb_AutoRefresh.Checked = s.Config_EnableAutomaticRefresh;
+            cb_ContinuousRefresh.Checked = s.Config_EnableContinuousRefresh;
             cb_AutoAdjustInterval.Checked = s.Config_AutoAdjustRefreshInterval;
-            cb_ScanOnStartup.Checked      = s.Config_ScanOnStartup;
-            cb_TrayNotify.Checked         = s.Config_EnableTrayNotificationsOnError;
-            num_RefreshInterval.Value     = Math.Max(num_RefreshInterval.Minimum,
+            cb_ScanOnStartup.Checked = s.Config_ScanOnStartup;
+            cb_TrayNotify.Checked = s.Config_EnableTrayNotificationsOnError;
+            num_RefreshInterval.Value = Math.Max(num_RefreshInterval.Minimum,
                                             Math.Min(num_RefreshInterval.Maximum, s.Config_AutomaticRefreshIntervalSeconds));
 
             int vIdx = s.Config_ValidationMethod;
             cmb_ValidationMethod.SelectedIndex = (vIdx >= 0 && vIdx < cmb_ValidationMethod.Items.Count) ? vIdx : 0;
-            cb_TestPing.Checked      = s.Config_TestPing;
+            cb_TestPing.Checked = s.Config_TestPing;
             cb_AllowRedirect.Checked = s.Config_AllowAutoRedirect;
-            cb_ValidateSSL.Checked   = s.Config_ValidateSSLCertificate;
-            num_PingTimeout.Value    = Clamp(s.Config_PingTimeoutSeconds,    num_PingTimeout.Minimum,    num_PingTimeout.Maximum);
-            num_HttpTimeout.Value    = Clamp(s.Config_HTTP_RequestTimeoutSeconds, num_HttpTimeout.Minimum, num_HttpTimeout.Maximum);
-            num_FtpTimeout.Value     = Clamp(s.Config_FTP_RequestTimeoutSeconds,  num_FtpTimeout.Minimum,  num_FtpTimeout.Maximum);
-            num_ParallelThreads.Value= Clamp(s.Config_ParallelThreadsCount,  num_ParallelThreads.Minimum, num_ParallelThreads.Maximum);
+            cb_ValidateSSL.Checked = s.Config_ValidateSSLCertificate;
+            num_PingTimeout.Value = Clamp(s.Config_PingTimeoutSeconds, num_PingTimeout.Minimum, num_PingTimeout.Maximum);
+            num_HttpTimeout.Value = Clamp(s.Config_HTTP_RequestTimeoutSeconds, num_HttpTimeout.Minimum, num_HttpTimeout.Maximum);
+            num_FtpTimeout.Value = Clamp(s.Config_FTP_RequestTimeoutSeconds, num_FtpTimeout.Minimum, num_FtpTimeout.Maximum);
+            num_ParallelThreads.Value = Clamp(s.Config_ParallelThreadsCount, num_ParallelThreads.Minimum, num_ParallelThreads.Maximum);
 
-            cb_ResolveDns.Checked    = s.Config_Resolve_DNS_Names;
-            cb_ResolveIp.Checked     = s.Config_Resolve_IP_Addresses;
-            cb_ResolveMac.Checked    = s.Config_Resolve_MAC_Addresses;
+            cb_ResolveDns.Checked = s.Config_Resolve_DNS_Names;
+            cb_ResolveIp.Checked = s.Config_Resolve_IP_Addresses;
+            cb_ResolveMac.Checked = s.Config_Resolve_MAC_Addresses;
             cb_ResolveShares.Checked = s.Config_ResolveNetworkShares;
-            cb_PageMetaInfo.Checked  = s.Config_ResolvePageMetaInfo;
+            cb_PageMetaInfo.Checked = s.Config_ResolvePageMetaInfo;
             cb_RemoveUrlParams.Checked = s.Config_RemoveURLParameters;
-            cb_PageLinks.Checked     = s.Config_ResolvePageLinks;
-            cb_SaveResponse.Checked  = s.Config_SaveResponse;
+            cb_PageLinks.Checked = s.Config_ResolvePageLinks;
+            cb_SaveResponse.Checked = s.Config_SaveResponse;
 
             cb_ExportXlsx.Checked = s.Config_ExportEndpointsStatus_XLSX;
             cb_ExportJson.Checked = s.Config_ExportEndpointsStatus_JSON;
-            cb_ExportXml.Checked  = s.Config_ExportEndpointsStatus_XML;
+            cb_ExportXml.Checked = s.Config_ExportEndpointsStatus_XML;
             cb_ExportHtml.Checked = s.Config_ExportEndpointsStatus_HTML;
-            txt_ExportDir.Text    = s.Config_EndpointsStatusExportDirectory;
+            txt_ExportDir.Text = s.Config_EndpointsStatusExportDirectory;
 
-            txt_VncPath.Text    = s.Config_Executable_VNCViewer;
-            txt_PuttyPath.Text  = s.Config_Executable_Putty;
+            txt_VncPath.Text = s.Config_Executable_VNCViewer;
+            txt_PuttyPath.Text = s.Config_Executable_Putty;
             txt_VirusTotal.Text = s.VirusTotal_API_Key;
             txt_GoogleMaps.Text = s.GoogleMaps_API_Key;
         }
@@ -283,50 +287,50 @@ namespace EndpointChecker
         {
             var s = Settings.Default;
 
-            s.Config_EnableAutomaticRefresh         = cb_AutoRefresh.Checked;
-            s.Config_EnableContinuousRefresh        = cb_ContinuousRefresh.Checked;
-            s.Config_AutoAdjustRefreshInterval      = cb_AutoAdjustInterval.Checked;
-            s.Config_ScanOnStartup                  = cb_ScanOnStartup.Checked;
+            s.Config_EnableAutomaticRefresh = cb_AutoRefresh.Checked;
+            s.Config_EnableContinuousRefresh = cb_ContinuousRefresh.Checked;
+            s.Config_AutoAdjustRefreshInterval = cb_AutoAdjustInterval.Checked;
+            s.Config_ScanOnStartup = cb_ScanOnStartup.Checked;
             s.Config_EnableTrayNotificationsOnError = cb_TrayNotify.Checked;
-            s.Config_AutomaticRefreshIntervalSeconds= num_RefreshInterval.Value;
+            s.Config_AutomaticRefreshIntervalSeconds = num_RefreshInterval.Value;
 
-            s.Config_ValidationMethod         = cmb_ValidationMethod.SelectedIndex;
-            s.Config_TestPing                 = cb_TestPing.Checked;
-            s.Config_AllowAutoRedirect        = cb_AllowRedirect.Checked;
-            s.Config_ValidateSSLCertificate   = cb_ValidateSSL.Checked;
-            s.Config_PingTimeoutSeconds       = num_PingTimeout.Value;
+            s.Config_ValidationMethod = cmb_ValidationMethod.SelectedIndex;
+            s.Config_TestPing = cb_TestPing.Checked;
+            s.Config_AllowAutoRedirect = cb_AllowRedirect.Checked;
+            s.Config_ValidateSSLCertificate = cb_ValidateSSL.Checked;
+            s.Config_PingTimeoutSeconds = num_PingTimeout.Value;
             s.Config_HTTP_RequestTimeoutSeconds = num_HttpTimeout.Value;
-            s.Config_FTP_RequestTimeoutSeconds  = num_FtpTimeout.Value;
-            s.Config_ParallelThreadsCount     = num_ParallelThreads.Value;
+            s.Config_FTP_RequestTimeoutSeconds = num_FtpTimeout.Value;
+            s.Config_ParallelThreadsCount = num_ParallelThreads.Value;
 
-            s.Config_Resolve_DNS_Names    = cb_ResolveDns.Checked;
+            s.Config_Resolve_DNS_Names = cb_ResolveDns.Checked;
             s.Config_Resolve_IP_Addresses = cb_ResolveIp.Checked;
             s.Config_Resolve_MAC_Addresses = cb_ResolveMac.Checked;
             s.Config_ResolveNetworkShares = cb_ResolveShares.Checked;
-            s.Config_ResolvePageMetaInfo  = cb_PageMetaInfo.Checked;
-            s.Config_RemoveURLParameters  = cb_RemoveUrlParams.Checked;
-            s.Config_ResolvePageLinks     = cb_PageLinks.Checked;
-            s.Config_SaveResponse         = cb_SaveResponse.Checked;
+            s.Config_ResolvePageMetaInfo = cb_PageMetaInfo.Checked;
+            s.Config_RemoveURLParameters = cb_RemoveUrlParams.Checked;
+            s.Config_ResolvePageLinks = cb_PageLinks.Checked;
+            s.Config_SaveResponse = cb_SaveResponse.Checked;
 
             s.Config_ExportEndpointsStatus_XLSX = cb_ExportXlsx.Checked;
             s.Config_ExportEndpointsStatus_JSON = cb_ExportJson.Checked;
-            s.Config_ExportEndpointsStatus_XML  = cb_ExportXml.Checked;
+            s.Config_ExportEndpointsStatus_XML = cb_ExportXml.Checked;
             s.Config_ExportEndpointsStatus_HTML = cb_ExportHtml.Checked;
             s.Config_EndpointsStatusExportDirectory = txt_ExportDir.Text.Trim();
 
             s.Config_Executable_VNCViewer = txt_VncPath.Text.Trim();
-            s.Config_Executable_Putty     = txt_PuttyPath.Text.Trim();
-            s.VirusTotal_API_Key          = txt_VirusTotal.Text.Trim();
-            s.GoogleMaps_API_Key          = txt_GoogleMaps.Text.Trim();
+            s.Config_Executable_Putty = txt_PuttyPath.Text.Trim();
+            s.VirusTotal_API_Key = txt_VirusTotal.Text.Trim();
+            s.GoogleMaps_API_Key = txt_GoogleMaps.Text.Trim();
 
             s.HasSavedConfiguration = true;
             s.Save();
 
             // Sync the Program-level static fields that LoadConfiguration reads from
-            Program.app_ScanOnStartup         = cb_ScanOnStartup.Checked;
-            Program.apiKey_VirusTotal         = txt_VirusTotal.Text.Trim();
-            Program.apiKey_GoogleMaps         = txt_GoogleMaps.Text.Trim();
-            CheckerMainForm.appExecutable_VNC   = txt_VncPath.Text.Trim();
+            Program.app_ScanOnStartup = cb_ScanOnStartup.Checked;
+            Program.apiKey_VirusTotal = txt_VirusTotal.Text.Trim();
+            Program.apiKey_GoogleMaps = txt_GoogleMaps.Text.Trim();
+            CheckerMainForm.appExecutable_VNC = txt_VncPath.Text.Trim();
             CheckerMainForm.appExecutable_Putty = txt_PuttyPath.Text.Trim();
             if (Directory.Exists(txt_ExportDir.Text.Trim()))
                 Program.statusExport_Directory = txt_ExportDir.Text.Trim();
@@ -354,7 +358,7 @@ namespace EndpointChecker
             using (OpenFileDialog ofd = new OpenFileDialog())
             {
                 ofd.Filter = "Executable files (*.exe)|*.exe|All files (*.*)|*.*";
-                ofd.Title  = "Select executable";
+                ofd.Title = "Select executable";
                 if (ofd.ShowDialog() == DialogResult.OK)
                     target.Text = ofd.FileName;
             }

--- a/src/EndpointManagementDialog.cs
+++ b/src/EndpointManagementDialog.cs
@@ -18,18 +18,18 @@ namespace EndpointChecker
         // Only endpoint lines are shown in the grid; comments are preserved on save.
         private sealed class FileLine
         {
-            public bool   IsEndpoint;
+            public bool IsEndpoint;
             public string Name;
             public string Url;
             public string Raw;   // original text for comment / blank lines
         }
 
         private List<FileLine> _lines;
-        private DataGridView   _grid;
+        private DataGridView _grid;
 
         public EndpointManagementDialog(CheckerMainForm owner)
         {
-            _owner    = owner;
+            _owner = owner;
             _filePath = Program.endpointDefinitionsFile;
             BuildUI();
             LoadFile();
@@ -40,56 +40,56 @@ namespace EndpointChecker
 
         private void BuildUI()
         {
-            Text            = "Endpoint Management";
-            Size            = new Size(720, 540);
+            Text = "Endpoint Management";
+            Size = new Size(720, 540);
             FormBorderStyle = FormBorderStyle.FixedDialog;
-            MaximizeBox     = false;
-            MinimizeBox     = false;
-            StartPosition   = FormStartPosition.CenterParent;
-            Font            = new Font("Segoe UI", 9f);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            Font = new Font("Segoe UI", 9f);
 
             _grid = new DataGridView
             {
-                Location              = new Point(8, 8),
-                Size                  = new Size(688, 420),
-                AllowUserToAddRows    = false,
+                Location = new Point(8, 8),
+                Size = new Size(688, 420),
+                AllowUserToAddRows = false,
                 AllowUserToDeleteRows = false,
-                RowHeadersVisible     = false,
-                SelectionMode         = DataGridViewSelectionMode.FullRowSelect,
-                MultiSelect           = false,
-                AutoSizeColumnsMode   = DataGridViewAutoSizeColumnsMode.None,
-                EditMode              = DataGridViewEditMode.EditOnEnter,
-                ClipboardCopyMode     = DataGridViewClipboardCopyMode.EnableWithoutHeaderText,
+                RowHeadersVisible = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None,
+                EditMode = DataGridViewEditMode.EditOnEnter,
+                ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableWithoutHeaderText,
             };
 
             var colName = new DataGridViewTextBoxColumn
             {
                 HeaderText = "Name",
-                Name       = "colName",
-                Width      = 180,
-                SortMode   = DataGridViewColumnSortMode.NotSortable,
+                Name = "colName",
+                Width = 180,
+                SortMode = DataGridViewColumnSortMode.NotSortable,
             };
             var colUrl = new DataGridViewTextBoxColumn
             {
                 HeaderText = "URL",
-                Name       = "colUrl",
-                Width      = 492,
-                SortMode   = DataGridViewColumnSortMode.NotSortable,
+                Name = "colUrl",
+                Width = 492,
+                SortMode = DataGridViewColumnSortMode.NotSortable,
             };
             _grid.Columns.AddRange(colName, colUrl);
 
-            var btnAdd    = new Button { Text = "Add",       Size = new Size(80, 26), Location = new Point(8,   442) };
-            var btnDelete = new Button { Text = "Delete",    Size = new Size(80, 26), Location = new Point(96,  442) };
-            var btnUp     = new Button { Text = "▲ Move Up", Size = new Size(88, 26), Location = new Point(184, 442) };
-            var btnDown   = new Button { Text = "▼ Move Down", Size = new Size(96, 26), Location = new Point(280, 442) };
-            var btnSave   = new Button { Text = "Save",      Size = new Size(80, 26), Location = new Point(520, 442), DialogResult = DialogResult.OK };
-            var btnCancel = new Button { Text = "Cancel",    Size = new Size(80, 26), Location = new Point(608, 442), DialogResult = DialogResult.Cancel };
+            var btnAdd = new Button { Text = "Add", Size = new Size(80, 26), Location = new Point(8, 442) };
+            var btnDelete = new Button { Text = "Delete", Size = new Size(80, 26), Location = new Point(96, 442) };
+            var btnUp = new Button { Text = "▲ Move Up", Size = new Size(88, 26), Location = new Point(184, 442) };
+            var btnDown = new Button { Text = "▼ Move Down", Size = new Size(96, 26), Location = new Point(280, 442) };
+            var btnSave = new Button { Text = "Save", Size = new Size(80, 26), Location = new Point(520, 442), DialogResult = DialogResult.OK };
+            var btnCancel = new Button { Text = "Cancel", Size = new Size(80, 26), Location = new Point(608, 442), DialogResult = DialogResult.Cancel };
 
-            btnAdd.Click    += BtnAdd_Click;
+            btnAdd.Click += BtnAdd_Click;
             btnDelete.Click += BtnDelete_Click;
-            btnUp.Click     += BtnUp_Click;
-            btnDown.Click   += BtnDown_Click;
-            btnSave.Click   += BtnSave_Click;
+            btnUp.Click += BtnUp_Click;
+            btnDown.Click += BtnDown_Click;
+            btnSave.Click += BtnSave_Click;
 
             Controls.AddRange(new Control[] { _grid, btnAdd, btnDelete, btnUp, btnDown, btnSave, btnCancel });
             AcceptButton = btnSave;
@@ -117,7 +117,7 @@ namespace EndpointChecker
                 {
                     string[] parts = trimmed.Split(new char[] { '|' }, 2);
                     string name = parts[0].Trim();
-                    string url  = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+                    string url = parts.Length > 1 ? parts[1].Trim() : string.Empty;
                     _lines.Add(new FileLine { IsEndpoint = true, Name = name, Url = url });
                     _grid.Rows.Add(name, url);
                 }
@@ -142,7 +142,7 @@ namespace EndpointChecker
                 if (gridIdx < _grid.Rows.Count)
                 {
                     fl.Name = (_grid.Rows[gridIdx].Cells[0].Value ?? string.Empty).ToString().Trim();
-                    fl.Url  = (_grid.Rows[gridIdx].Cells[1].Value ?? string.Empty).ToString().Trim();
+                    fl.Url = (_grid.Rows[gridIdx].Cells[1].Value ?? string.Empty).ToString().Trim();
                     gridIdx++;
                 }
             }
@@ -227,10 +227,10 @@ namespace EndpointChecker
         {
             var row = _grid.Rows[a];
             object nameA = row.Cells[0].Value;
-            object urlA  = row.Cells[1].Value;
+            object urlA = row.Cells[1].Value;
             var rowB = _grid.Rows[b];
-            row.Cells[0].Value  = rowB.Cells[0].Value;
-            row.Cells[1].Value  = rowB.Cells[1].Value;
+            row.Cells[0].Value = rowB.Cells[0].Value;
+            row.Cells[1].Value = rowB.Cells[1].Value;
             rowB.Cells[0].Value = nameA;
             rowB.Cells[1].Value = urlA;
         }
@@ -243,11 +243,11 @@ namespace EndpointChecker
             if (lineA == null || lineB == null)
                 return;
             string tmpName = lineA.Name;
-            string tmpUrl  = lineA.Url;
+            string tmpUrl = lineA.Url;
             lineA.Name = lineB.Name;
-            lineA.Url  = lineB.Url;
+            lineA.Url = lineB.Url;
             lineB.Name = tmpName;
-            lineB.Url  = tmpUrl;
+            lineB.Url = tmpUrl;
         }
 
         private FileLine GetEndpointLine(int gridIndex)

--- a/src/FontPublisher.cs
+++ b/src/FontPublisher.cs
@@ -34,7 +34,7 @@ namespace EndpointChecker
 
                 Registry.SetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts",
                                   actualFontName, resourceFileName, RegistryValueKind.String);
-            }           
+            }
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -138,6 +138,7 @@ namespace EndpointChecker
         public static string app_LatestPackageLink = string.Empty;
         public static string app_LatestPackageDate = string.Empty;
         public static string app_LatestPackageReleaseNotes_RTF = string.Empty;
+        private static readonly bool app_UpdateChecksEnabled = false;
 
         // SIGNING CERTIFICATE
         public static bool app_IsOriginalSignedExecutable = IsOriginalSignedExecutable();
@@ -307,7 +308,7 @@ namespace EndpointChecker
                         }
                     }
                 }
-            }            
+            }
         }
 
         public static bool RequiredLibrariesExists(string[] librariesList)
@@ -404,6 +405,17 @@ namespace EndpointChecker
 
         public static void CheckForUpdate()
         {
+            if (!app_UpdateChecksEnabled)
+            {
+                app_UpdateAvailable = false;
+                app_AutoUpdateNow = false;
+                app_LatestPackageVersion = app_Version;
+                app_LatestPackageLink = string.Empty;
+                app_LatestPackageDate = string.Empty;
+                app_LatestPackageReleaseNotes_RTF = string.Empty;
+                return;
+            }
+
             try
             {
                 using (CustomWebClient updateWC = new CustomWebClient())
@@ -435,7 +447,7 @@ namespace EndpointChecker
                             "https://raw.githubusercontent.com/ThePhOeNiX810815/Endpoint-Status-Checker/Main-Dev-Branch/release_notes.rtf");
 
                     if ((app_LatestPackageVersion > app_Version &&
-                         app_LatestPackageVersion > app_AutoUpdate_SkipVersion) || 
+                         app_LatestPackageVersion > app_AutoUpdate_SkipVersion) ||
                         app_TestMode)
                     {
                         app_UpdateAvailable = true;
@@ -485,8 +497,8 @@ namespace EndpointChecker
             {
                 X509Certificate2 cert = new X509Certificate2(X509Certificate.CreateFromSignedFile(app_Assembly.Location));
 
-                string serial  = cert.GetSerialNumberString();
-                string issuer  = cert.Issuer;
+                string serial = cert.GetSerialNumberString();
+                string issuer = cert.Issuer;
                 string subject = cert.Subject;
 
                 // Peter Machaj (original developer)
@@ -654,7 +666,7 @@ namespace EndpointChecker
             }
             catch
             {
-            }         
+            }
 
             return isInstalled;
         }

--- a/src/SpeedTestDialog.cs
+++ b/src/SpeedTestDialog.cs
@@ -955,11 +955,11 @@ namespace EndpointChecker
                                         Color.LightGreen,
                                         true);
 
-                                ThreadSafeInvoke(() =>
-                                {
-                                    lbl_DownloadHint.Text = "Sampling sustained transfer rate with staged payload streams";
-                                    lbl_DownloadHint.ForeColor = colorInfo;
-                                });
+                    ThreadSafeInvoke(() =>
+                    {
+                        lbl_DownloadHint.Text = "Sampling sustained transfer rate with staged payload streams";
+                        lbl_DownloadHint.ForeColor = colorInfo;
+                    });
 
                     // TEST DOWNLOAD SPEED
                     int downloadSpeed = TestServerDownloadSpeed();

--- a/tools/EndpointChecker-Updater/EndpointChecker-Updater.csproj
+++ b/tools/EndpointChecker-Updater/EndpointChecker-Updater.csproj
@@ -11,7 +11,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <Version>1.0.0</Version>
-    <Description>Standalone updater - upgrades Endpoint Status Checker from any previous version to v3.1.0</Description>
+    <Description>Standalone updater - currently disabled until an official v3 release is published</Description>
     <Copyright>Peter Machaj</Copyright>
     <ApplicationIcon>..\..\src\app.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>

--- a/tools/EndpointChecker-Updater/Program.cs
+++ b/tools/EndpointChecker-Updater/Program.cs
@@ -25,9 +25,9 @@ namespace EndpointCheckerUpdater
     {
         // ── Constants ────────────────────────────────────────────────────────────
 
-        const string DownloadUrl = "https://github.com/ThePhOeNiX810815/Endpoint-Status-Checker/releases/download/v3.1.0/EndpointChecker-v3.1.0-win-x86.zip";
-        const string TargetVer   = "3.1.0";
-        const string AppExe      = "EndpointChecker.exe";
+        const string DownloadUrl = "";
+        const string TargetVer = "development build";
+        const string AppExe = "EndpointChecker.exe";
 
         // User data files that must survive the update
         static readonly string[] UserDataFiles =
@@ -38,9 +38,9 @@ namespace EndpointCheckerUpdater
 
         // ── Controls ─────────────────────────────────────────────────────────────
 
-        private TextBox     _txtDir;
-        private Label       _lblVersion, _lblStatus;
-        private Button      _btnBrowse, _btnUpdate, _btnClose;
+        private TextBox _txtDir;
+        private Label _lblVersion, _lblStatus;
+        private Button _btnBrowse, _btnUpdate, _btnClose;
         private ProgressBar _progress;
         private RichTextBox _log;
 
@@ -56,15 +56,15 @@ namespace EndpointCheckerUpdater
 
         private void BuildUI()
         {
-            Text            = $"Endpoint Status Checker — Updater to v{TargetVer}";
-            Size            = new Size(580, 500);
-            MinimumSize     = Size;
+            Text = "Endpoint Status Checker — Updater unavailable";
+            Size = new Size(580, 500);
+            MinimumSize = Size;
             FormBorderStyle = FormBorderStyle.FixedDialog;
-            MaximizeBox     = MinimizeBox = false;
-            StartPosition   = FormStartPosition.CenterScreen;
-            Font            = new Font("Segoe UI", 9f);
-            BackColor       = Color.FromArgb(22, 19, 25);
-            ForeColor       = Color.WhiteSmoke;
+            MaximizeBox = MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterScreen;
+            Font = new Font("Segoe UI", 9f);
+            BackColor = Color.FromArgb(22, 19, 25);
+            ForeColor = Color.WhiteSmoke;
 
             // Header
             var lblTitle = MakeLabel(
@@ -74,7 +74,7 @@ namespace EndpointCheckerUpdater
                 new Font("Segoe UI", 13f, FontStyle.Bold));
 
             var lblSub = MakeLabel(
-                $"Upgrades any previous version to v{TargetVer}  ·  .NET 10  ·  self-contained x86  ·  no runtime required",
+                "Official v3 updates are not available yet. Use a manually provided test build only.",
                 16, 44, 544, 18, Color.Silver);
 
             var sep1 = MakeSep(70);
@@ -86,10 +86,10 @@ namespace EndpointCheckerUpdater
 
             _txtDir = new TextBox
             {
-                Location    = new Point(14, 102),
-                Size        = new Size(446, 22),
-                BackColor   = Color.FromArgb(30, 35, 60),
-                ForeColor   = Color.WhiteSmoke,
+                Location = new Point(14, 102),
+                Size = new Size(446, 22),
+                BackColor = Color.FromArgb(30, 35, 60),
+                ForeColor = Color.WhiteSmoke,
                 BorderStyle = BorderStyle.FixedSingle
             };
 
@@ -104,32 +104,33 @@ namespace EndpointCheckerUpdater
             _progress = new ProgressBar
             {
                 Location = new Point(14, 162),
-                Size     = new Size(548, 16),
-                Minimum  = 0,
-                Maximum  = 100,
-                Style    = ProgressBarStyle.Continuous
+                Size = new Size(548, 16),
+                Minimum = 0,
+                Maximum = 100,
+                Style = ProgressBarStyle.Continuous
             };
 
             _lblStatus = MakeLabel(
-                "Ready.  Select the install directory then click Start Update.",
+                "Updater disabled until an official v3 release is published.",
                 14, 182, 548, 18);
 
             // Log
             _log = new RichTextBox
             {
-                Location    = new Point(14, 206),
-                Size        = new Size(548, 212),
-                ReadOnly    = true,
-                BackColor   = Color.FromArgb(15, 15, 20),
-                ForeColor   = Color.FromArgb(160, 200, 160),
+                Location = new Point(14, 206),
+                Size = new Size(548, 212),
+                ReadOnly = true,
+                BackColor = Color.FromArgb(15, 15, 20),
+                ForeColor = Color.FromArgb(160, 200, 160),
                 BorderStyle = BorderStyle.FixedSingle,
-                Font        = new Font("Consolas", 8.5f),
-                ScrollBars  = RichTextBoxScrollBars.Vertical
+                Font = new Font("Consolas", 8.5f),
+                ScrollBars = RichTextBoxScrollBars.Vertical
             };
 
             // Buttons
             _btnUpdate = MakeButton("Start Update", 358, 428, 108, 30,
                 Color.FromArgb(25, 90, 45), Color.FromArgb(45, 150, 75));
+            _btnUpdate.Enabled = false;
             _btnUpdate.Click += BtnUpdate_Click;
 
             _btnClose = MakeButton("Close", 474, 428, 88, 30,
@@ -149,26 +150,30 @@ namespace EndpointCheckerUpdater
             Color? color = null, Font font = null) =>
             new Label
             {
-                Text      = text,
-                Location  = new Point(x, y),
-                Size      = new Size(w, h),
-                AutoSize  = false,
+                Text = text,
+                Location = new Point(x, y),
+                Size = new Size(w, h),
+                AutoSize = false,
                 ForeColor = color ?? Color.Silver,
-                Font      = font
+                Font = font
             };
 
         private static Label MakeSep(int y) =>
-            new Label { Location = new Point(0, y), Size = new Size(580, 1),
-                        BackColor = Color.FromArgb(50, 50, 70) };
+            new Label
+            {
+                Location = new Point(0, y),
+                Size = new Size(580, 1),
+                BackColor = Color.FromArgb(50, 50, 70)
+            };
 
         private static Button MakeButton(string text, int x, int y, int w, int h,
             Color? bg = null, Color? border = null)
         {
             var b = new Button
             {
-                Text      = text,
-                Location  = new Point(x, y),
-                Size      = new Size(w, h),
+                Text = text,
+                Location = new Point(x, y),
+                Size = new Size(w, h),
                 FlatStyle = FlatStyle.Flat,
                 BackColor = bg ?? Color.FromArgb(40, 50, 90),
                 ForeColor = Color.WhiteSmoke
@@ -193,9 +198,9 @@ namespace EndpointCheckerUpdater
             }
 
             // 2. Common candidate locations
-            string desktop  = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            string profile  = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            string progFiles   = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            string desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            string profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string progFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
             string progFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
 
             foreach (string candidate in new[]
@@ -226,18 +231,18 @@ namespace EndpointCheckerUpdater
                 try
                 {
                     var vi = FileVersionInfo.GetVersionInfo(exePath);
-                    _lblVersion.Text      = $"Detected:  v{vi.FileVersion}  →  will upgrade to v{TargetVer}";
+                    _lblVersion.Text = $"Detected:  v{vi.FileVersion}  →  no official v3 update available";
                     _lblVersion.ForeColor = Color.FromArgb(100, 200, 100);
                 }
                 catch
                 {
-                    _lblVersion.Text      = "Detected: EndpointChecker.exe found (version unknown)  →  will upgrade to v" + TargetVer;
+                    _lblVersion.Text = "Detected: EndpointChecker.exe found (version unknown)  →  no official v3 update available";
                     _lblVersion.ForeColor = Color.FromArgb(100, 200, 100);
                 }
             }
             else
             {
-                _lblVersion.Text      = "EndpointChecker.exe not found in this folder.";
+                _lblVersion.Text = "EndpointChecker.exe not found in this folder.";
                 _lblVersion.ForeColor = Color.Orange;
             }
         }
@@ -246,7 +251,7 @@ namespace EndpointCheckerUpdater
         {
             using (var dlg = new FolderBrowserDialog
             {
-                Description  = "Select the folder that contains EndpointChecker.exe",
+                Description = "Select the folder that contains EndpointChecker.exe",
                 SelectedPath = _txtDir.Text
             })
             {
@@ -257,42 +262,26 @@ namespace EndpointCheckerUpdater
 
         // ── Update logic ─────────────────────────────────────────────────────────
 
-        private async void BtnUpdate_Click(object sender, EventArgs e)
+        private void BtnUpdate_Click(object sender, EventArgs e)
         {
-            string dir = _txtDir.Text.Trim();
-
-            if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
-            {
-                MessageBox.Show("Please select a valid install directory.",
-                    Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            SetControlsEnabled(false);
-
-            try
-            {
-                await RunUpdateAsync(dir);
-            }
-            catch (Exception ex)
-            {
-                Log($"ERROR: {ex.Message}", Color.OrangeRed);
-                Status("Update failed — see log above.", Color.OrangeRed);
-                SetControlsEnabled(true);
-            }
+            MessageBox.Show(
+                "Official v3 updates are not available yet.",
+                Text,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Information);
         }
 
         private void SetControlsEnabled(bool enabled)
         {
             _btnUpdate.Enabled = enabled;
             _btnBrowse.Enabled = enabled;
-            _txtDir.Enabled    = enabled;
-            _btnClose.Enabled  = enabled;
+            _txtDir.Enabled = enabled;
+            _btnClose.Enabled = enabled;
         }
 
         private async Task RunUpdateAsync(string installDir)
         {
-            string tempZip     = Path.Combine(Path.GetTempPath(), "EndpointChecker-v3.1.0-win-x86.zip");
+            string tempZip = Path.Combine(Path.GetTempPath(), "EndpointChecker-v3-unpublished-win-x86.zip");
             string tempExtract = Path.Combine(Path.GetTempPath(), "EndpointChecker_Updater_Extract");
 
             // ── Step 1: Stop running instance ────────────────────────────────────
@@ -319,7 +308,7 @@ namespace EndpointCheckerUpdater
             Progress(3);
 
             // ── Step 2: Download ─────────────────────────────────────────────────
-            Status("Downloading v3.1.0 from GitHub (~102 MB)...");
+            Status("Downloading official v3 package from GitHub...");
             Log($"Downloading: {DownloadUrl}");
 
             using (var wc = new WebClient())
@@ -376,7 +365,7 @@ namespace EndpointCheckerUpdater
             {
                 foreach (string src in Directory.GetFiles(tempExtract, "*", SearchOption.AllDirectories))
                 {
-                    string rel  = src.Substring(tempExtract.Length).TrimStart(Path.DirectorySeparatorChar);
+                    string rel = src.Substring(tempExtract.Length).TrimStart(Path.DirectorySeparatorChar);
                     string dest = Path.Combine(installDir, rel);
                     Directory.CreateDirectory(Path.GetDirectoryName(dest));
                     File.Copy(src, dest, overwrite: true);
@@ -430,7 +419,7 @@ namespace EndpointCheckerUpdater
         {
             if (InvokeRequired) { Invoke(new Action(() => Status(text, color))); return; }
             _lblStatus.ForeColor = color == default ? Color.Silver : color;
-            _lblStatus.Text      = text;
+            _lblStatus.Text = text;
         }
 
         private void Progress(int value)
@@ -442,9 +431,9 @@ namespace EndpointCheckerUpdater
         private void Log(string text, Color color = default)
         {
             if (InvokeRequired) { Invoke(new Action(() => Log(text, color))); return; }
-            _log.SelectionStart  = _log.TextLength;
+            _log.SelectionStart = _log.TextLength;
             _log.SelectionLength = 0;
-            _log.SelectionColor  = color == default ? Color.FromArgb(160, 200, 160) : color;
+            _log.SelectionColor = color == default ? Color.FromArgb(160, 200, 160) : color;
             _log.AppendText(text + "\n");
             _log.ScrollToCaret();
         }


### PR DESCRIPTION
## Summary
- apply dotnet format whitespace cleanup to the app solution and updater project
- update README to say v3 has no official release yet and remove v3 release download links
- disable in-app v3 update checks while no official v3 release exists
- disable the standalone updater UI and remove stale v3.1.0 release references

## Test package
Created local test build ZIP for manual validation:

/tmp/EndpointChecker-v3-test-build.zip

The README does not reference this ZIP yet. That follow-up is intentionally deferred until the test app is confirmed working.

## Verification
- dotnet format src/EndpointChecker.sln --verify-no-changes --no-restore
- dotnet format tools/EndpointChecker-Updater/EndpointChecker-Updater.csproj --verify-no-changes --no-restore
- dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet clean src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -p:RunAnalyzers=true -v:minimal
- dotnet build tools/EndpointChecker-Updater/EndpointChecker-Updater.csproj --no-restore -p:EnableWindowsTargeting=true -p:RunAnalyzers=true -v:minimal
- dotnet run --project tests/StructuredExport.Tests/StructuredExport.Tests.csproj
- dotnet run --project tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj
- dotnet run --project tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj
- dotnet run --project tests/ExportOptions.Tests/ExportOptions.Tests.csproj
- dotnet run --project tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet run --project tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj
- dotnet publish src/EndpointChecker.csproj -c Release -p:Platform=x86 -p:EnableWindowsTargeting=true -o /tmp/EndpointChecker-v3-test-build
- git diff --check