### PR TITLE
refactor: decompose scan protocol routing selection

### DIFF
--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -754,10 +754,12 @@ namespace EndpointChecker
                                         // CREATE STOPWATCH FOR ITEM CHECK DURATION [FOR 'EXPORT' PURPOSE]
                                         Stopwatch sw_ItemProgress = new Stopwatch();
 
-                                        if (EndpointScanWorkflowRules.IsHttpProtocolCheck(
+                                        EndpointProtocolRoute protocolRoute = EndpointProtocolRouteResolver.Resolve(
                                             validationMethod == ValidationMethod.Protocol,
                                             BW_GetStatus.CancellationPending,
-                                            endpoint.Protocol))
+                                            endpoint.Protocol);
+
+                                        if (protocolRoute == EndpointProtocolRoute.Http)
                                         {
                                             // AUTO-REDIRECT SWITCH [BY 'LOCATION' HEADER OF '3xx' RESPONSE CODE]
                                             bool autoRedirect_Followed = false;
@@ -1107,10 +1109,7 @@ namespace EndpointChecker
                                                 }
                                             }
                                         }
-                                        else if (EndpointScanWorkflowRules.IsFtpProtocolCheck(
-                                            validationMethod == ValidationMethod.Protocol,
-                                            BW_GetStatus.CancellationPending,
-                                            endpoint.Protocol))
+                                        else if (protocolRoute == EndpointProtocolRoute.Ftp)
                                         {
                                             // FTP PROTOCOL SCHEME
                                             FtpWebRequest ftpWebRequest;

--- a/src/EndpointProtocolRouteResolver.cs
+++ b/src/EndpointProtocolRouteResolver.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace EndpointChecker
+{
+    internal enum EndpointProtocolRoute
+    {
+        None = 0,
+        Http = 1,
+        Ftp = 2
+    }
+
+    internal static class EndpointProtocolRouteResolver
+    {
+        public static EndpointProtocolRoute Resolve(bool isProtocolValidation, bool cancellationPending, string protocol)
+        {
+            if (!isProtocolValidation || cancellationPending)
+            {
+                return EndpointProtocolRoute.None;
+            }
+
+            if (string.Equals(protocol, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(protocol, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                return EndpointProtocolRoute.Http;
+            }
+
+            if (string.Equals(protocol, Uri.UriSchemeFtp, StringComparison.OrdinalIgnoreCase))
+            {
+                return EndpointProtocolRoute.Ftp;
+            }
+
+            return EndpointProtocolRoute.None;
+        }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckOptionsTests.cs
@@ -171,6 +171,7 @@ namespace EndpointChecker
         {
             Run("HTTP protocol routing respects protocol validation and cancellation", HttpProtocolRoutingRespectsProtocolValidationAndCancellation);
             Run("FTP protocol routing respects protocol validation and cancellation", FtpProtocolRoutingRespectsProtocolValidationAndCancellation);
+            Run("Protocol route resolver maps HTTP HTTPS FTP and None", ProtocolRouteResolverMapsHttpHttpsFtpAndNone);
             Run("Manual redirect follow requires 3xx and location header", ManualRedirectFollowRequires3xxAndLocationHeader);
             Run("Redirect annotation follows URI changes and explicit follow flag", RedirectAnnotationFollowsUriChangesAndExplicitFollowFlag);
             Run("Ping check message is set only in ping validation mode", PingCheckMessageIsSetOnlyInPingValidationMode);
@@ -195,6 +196,16 @@ namespace EndpointChecker
             EndpointCheckingCoreTestRunner.AssertEqual(false, EndpointScanWorkflowRules.IsFtpProtocolCheck(true, true, "ftp"));
             EndpointCheckingCoreTestRunner.AssertEqual(false, EndpointScanWorkflowRules.IsFtpProtocolCheck(false, false, "ftp"));
             EndpointCheckingCoreTestRunner.AssertEqual(false, EndpointScanWorkflowRules.IsFtpProtocolCheck(true, false, "http"));
+        }
+
+        private static void ProtocolRouteResolverMapsHttpHttpsFtpAndNone()
+        {
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.Http, EndpointProtocolRouteResolver.Resolve(true, false, "http"));
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.Http, EndpointProtocolRouteResolver.Resolve(true, false, "HTTPS"));
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.Ftp, EndpointProtocolRouteResolver.Resolve(true, false, "ftp"));
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.None, EndpointProtocolRouteResolver.Resolve(true, false, "mailto"));
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.None, EndpointProtocolRouteResolver.Resolve(false, false, "http"));
+            EndpointCheckingCoreTestRunner.AssertEqual(EndpointProtocolRoute.None, EndpointProtocolRouteResolver.Resolve(true, true, "http"));
         }
 
         private static void ManualRedirectFollowRequires3xxAndLocationHeader()

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
@@ -12,6 +12,7 @@
     <Compile Include="..\..\src\EndpointCheckProgressSnapshot.cs" Link="EndpointCheckProgressSnapshot.cs" />
     <Compile Include="..\..\src\EndpointCheckProgressWorkItem.cs" Link="EndpointCheckProgressWorkItem.cs" />
     <Compile Include="..\..\src\EndpointCheckResultFactory.cs" Link="EndpointCheckResultFactory.cs" />
+    <Compile Include="..\..\src\EndpointProtocolRouteResolver.cs" Link="EndpointProtocolRouteResolver.cs" />
     <Compile Include="..\..\src\EndpointScanWorkflowRules.cs" Link="EndpointScanWorkflowRules.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- extract protocol route selection in bw_GetStatus_DoWork into EndpointProtocolRouteResolver
- switch scan worker protocol branching to resolved route enum instead of direct inline protocol condition checks
- add deterministic characterization tests for protocol route mapping behavior
- keep HTTP/FTP execution paths and observable endpoint-check behavior unchanged

## Verification
- dotnet run --project tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:minimal
- dotnet restore src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet clean src/EndpointChecker.csproj -p:EnableWindowsTargeting=true
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -p:RunAnalyzers=true -t:Rebuild -v:minimal
- full standalone suites executed (EndpointDefinitionParser, EndpointCheckingCore, HttpCompatibility, ExportOptions, ExportRunSummary, ExportFileSet, StructuredExport)
- dotnet format whitespace src/EndpointChecker.sln --verify-no-changes --no-restore (pass)
- dotnet format src/EndpointChecker.sln --verify-no-changes --no-restore (exit 2 due existing broader formatting drift; not analyzer-only)

## Compatibility
- no worker model redesign
- no network dependency additions
- no repository-wide formatting changes