### PR TITLE
refactor: extract HTML export compatibility transformer

### DIFF
--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -3433,88 +3433,17 @@ namespace EndpointChecker
 
         public string AddAutoRefreshToHTMLString(string inputHTML, int refreshIntervalSeconds)
         {
-            return inputHTML.Replace("<head>", "<head>" + Environment.NewLine + "<meta http-equiv=\"refresh\" content=\"" + refreshIntervalSeconds + "\">");
+            return EndpointHtmlExportTransformer.AddAutoRefreshMetaTag(inputHTML, refreshIntervalSeconds);
         }
 
         public string CreateEndpointURLHyperLink(string inputHTML)
         {
-            // REMOVE ESCAPE CHARACTERS
-            string inputXMLString = inputHTML
-                .Replace("&nbsp;", " ")
-                .Replace("&", "&amp;");
-
-            // LOAD AS XML
-            XmlDocument inputHTMLDoc = new XmlDocument();
-            inputHTMLDoc.LoadXml(inputXMLString);
-
-            XmlNodeList trNodesList = inputHTMLDoc.GetElementsByTagName("tr");
-
-            int trNodeIndex = 0;
-            foreach (XmlNode trNode in trNodesList)
-            {
-                if (trNodeIndex > 0)
-                {
-                    // ADD 'ONCLICK' HANDLER
-                    XmlAttribute attr = inputHTMLDoc.CreateAttribute("onclick");
-                    attr.Value = "location.href = '" +
-                                 trNode.ChildNodes[3].ChildNodes[0].InnerXml +
-                                 "'";
-
-                    trNode.ChildNodes[3].ChildNodes[0].Attributes.Append(attr);
-
-                    using (StringWriter stringWriter = new StringWriter())
-                    using (XmlWriter xmlTextWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { Indent = true, NewLineOnAttributes = false, OmitXmlDeclaration = true }))
-                    {
-                        inputHTMLDoc.WriteTo(xmlTextWriter);
-                        xmlTextWriter.Flush();
-                        inputHTML = stringWriter.GetStringBuilder().ToString();
-                    }
-                }
-
-                trNodeIndex++;
-            }
-
-            // SET 'HAND' CURSOR TO CLASSES DEFINING HYPERLINK [UNDERLINED STYLE]
-            foreach (string htmlLine in inputXMLString.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
-            {
-                if (htmlLine.StartsWith(".X") &&
-                    htmlLine.Contains("text-decoration:underline"))
-                {
-                    // SET 'HAND' CURSOR TO AFFECTED NODES
-                    inputHTML = inputHTML.Replace(
-                        htmlLine.Split('{')[1],
-                        "cursor:pointer;" + htmlLine.Split('{')[1]);
-                }
-            }
-
-            return inputHTML;
+            return EndpointHtmlExportTransformer.CreateEndpointUrlHyperLinks(inputHTML);
         }
 
         public string AddRefreshCSSButtonToHTMLString(string inputHTML)
         {
-            return inputHTML.Replace(
-                                    @"<html xmlns=""http://www.w3.org/1999/xhtml"">
-  <head>
-    <style type=""text/css"">table",
-                                    @"<html xmlns=""http://www.w3.org/1999/xhtml"">
-<INPUT TYPE=""button"" onClick=""window.location.reload()"" VALUE=""Refresh"" ID=""refreshBTN"">
-  <head>
-    <style type=""text/css"">
-    body {
-            background - color: #CCC;
-            margin: 32px 0px 0px 0px;
-                                }
-                                INPUT#refreshBTN {
-                                position: fixed;
-                                top: 0px;
-                                left: 0px;
-                                width: 100%;
-                                color: #7CFC00;
-                                background: #333;
-                                padding: 5px;
-                                cursor:pointer;
-                                }
-                            table");
+            return EndpointHtmlExportTransformer.AddRefreshCssButton(inputHTML);
         }
 
         public Color GetColorByStatus(string statusCode, string pingTime, string statusMessage)

--- a/src/EndpointHtmlExportTransformer.cs
+++ b/src/EndpointHtmlExportTransformer.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Xml;
+
+namespace EndpointChecker
+{
+    internal static class EndpointHtmlExportTransformer
+    {
+        public static string AddAutoRefreshMetaTag(string inputHtml, int refreshIntervalSeconds)
+        {
+            return inputHtml.Replace("<head>", "<head>" + Environment.NewLine + "<meta http-equiv=\"refresh\" content=\"" + refreshIntervalSeconds + "\">");
+        }
+
+        public static string CreateEndpointUrlHyperLinks(string inputHtml)
+        {
+            // Preserve the current HTML-to-XML conversion behavior used by the legacy export path.
+            string inputXmlString = inputHtml
+                .Replace("&nbsp;", " ")
+                .Replace("&", "&amp;");
+
+            XmlDocument inputHtmlDoc = new XmlDocument();
+            inputHtmlDoc.LoadXml(inputXmlString);
+
+            XmlNodeList trNodesList = inputHtmlDoc.GetElementsByTagName("tr");
+
+            int trNodeIndex = 0;
+            foreach (XmlNode trNode in trNodesList)
+            {
+                if (trNodeIndex > 0)
+                {
+                    XmlAttribute attr = inputHtmlDoc.CreateAttribute("onclick");
+                    attr.Value = "location.href = '" +
+                                 trNode.ChildNodes[3].ChildNodes[0].InnerXml +
+                                 "'";
+
+                    trNode.ChildNodes[3].ChildNodes[0].Attributes.Append(attr);
+
+                    using (StringWriter stringWriter = new StringWriter())
+                    using (XmlWriter xmlTextWriter = XmlWriter.Create(stringWriter, new XmlWriterSettings { Indent = true, NewLineOnAttributes = false, OmitXmlDeclaration = true }))
+                    {
+                        inputHtmlDoc.WriteTo(xmlTextWriter);
+                        xmlTextWriter.Flush();
+                        inputHtml = stringWriter.GetStringBuilder().ToString();
+                    }
+                }
+
+                trNodeIndex++;
+            }
+
+            foreach (string htmlLine in inputXmlString.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (htmlLine.StartsWith(".X") &&
+                    htmlLine.Contains("text-decoration:underline"))
+                {
+                    inputHtml = inputHtml.Replace(
+                        htmlLine.Split('{')[1],
+                        "cursor:pointer;" + htmlLine.Split('{')[1]);
+                }
+            }
+
+            return inputHtml;
+        }
+
+        public static string AddRefreshCssButton(string inputHtml)
+        {
+            return inputHtml.Replace(
+                                    @"<html xmlns=""http://www.w3.org/1999/xhtml"">
+  <head>
+    <style type=""text/css"">table",
+                                    @"<html xmlns=""http://www.w3.org/1999/xhtml"">
+<INPUT TYPE=""button"" onClick=""window.location.reload()"" VALUE=""Refresh"" ID=""refreshBTN"">
+  <head>
+    <style type=""text/css"">
+    body {
+            background - color: #CCC;
+            margin: 32px 0px 0px 0px;
+                                }
+                                INPUT#refreshBTN {
+                                position: fixed;
+                                top: 0px;
+                                left: 0px;
+                                width: 100%;
+                                color: #7CFC00;
+                                background: #333;
+                                padding: 5px;
+                                cursor:pointer;
+                                }
+                            table");
+        }
+    }
+}

--- a/tests/StructuredExport.Tests/EndpointStructuredExportGeneratorTests.cs
+++ b/tests/StructuredExport.Tests/EndpointStructuredExportGeneratorTests.cs
@@ -13,6 +13,9 @@ namespace EndpointChecker
             Run("JSON export remains indented", JsonExportRemainsIndented);
             Run("XML export preserves root shape", XmlExportPreservesRootShape);
             Run("XML export preserves Encoding plus workaround", XmlExportPreservesEncodingPlusWorkaround);
+            Run("HTML export adds auto refresh meta tag", HtmlExportAddsAutoRefreshMetaTag);
+            Run("HTML export injects endpoint row hyperlink click handler", HtmlExportInjectsEndpointRowHyperlinkClickHandler);
+            Run("HTML export injects refresh button CSS block", HtmlExportInjectsRefreshButtonCssBlock);
 
             if (failed > 0)
             {
@@ -53,6 +56,49 @@ namespace EndpointChecker
             XmlDocument document = EndpointStructuredExportGenerator.CreateXmlDocument(json);
 
             AssertEqual("utf-8", document.DocumentElement.SelectSingleNode("EndpointStatus/Encoding_Name").InnerText);
+        }
+
+        private static void HtmlExportAddsAutoRefreshMetaTag()
+        {
+            string inputHtml = "<html><head><title>x</title></head><body></body></html>";
+            string outputHtml = EndpointHtmlExportTransformer.AddAutoRefreshMetaTag(inputHtml, 30);
+
+            AssertContains("<meta http-equiv=\"refresh\" content=\"30\">", outputHtml);
+        }
+
+        private static void HtmlExportInjectsEndpointRowHyperlinkClickHandler()
+        {
+            string inputHtml = @"<html>
+<head>
+<style type=""text/css"">
+.X1{text-decoration:underline;color:#00f;}
+</style>
+</head>
+<body>
+<table>
+<tr><td>Header</td><td>Header</td><td>Header</td><td><a>Address</a></td></tr>
+<tr><td>Name</td><td>HTTP</td><td>443</td><td><a>https://example.test</a></td></tr>
+</table>
+</body>
+</html>";
+
+            string outputHtml = EndpointHtmlExportTransformer.CreateEndpointUrlHyperLinks(inputHtml);
+
+            AssertContains("onclick=\"location.href = 'https://example.test'\"", outputHtml);
+            AssertContains("cursor:pointer;", outputHtml);
+        }
+
+        private static void HtmlExportInjectsRefreshButtonCssBlock()
+        {
+                        string inputHtml = "<html xmlns=\"http://www.w3.org/1999/xhtml\">" + Environment.NewLine +
+                                                             "  <head>" + Environment.NewLine +
+                                                             "    <style type=\"text/css\">table";
+
+            string outputHtml = EndpointHtmlExportTransformer.AddRefreshCssButton(inputHtml);
+
+            AssertContains("ID=\"refreshBTN\"", outputHtml);
+            AssertContains("window.location.reload()", outputHtml);
+            AssertContains("cursor:pointer;", outputHtml);
         }
 
         private static void Run(string name, Action test)

--- a/tests/StructuredExport.Tests/StructuredExport.Tests.csproj
+++ b/tests/StructuredExport.Tests/StructuredExport.Tests.csproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <Compile Include="..\..\src\EndpointStructuredExportGenerator.cs" Link="EndpointStructuredExportGenerator.cs" />
+    <Compile Include="..\..\src\EndpointHtmlExportTransformer.cs" Link="EndpointHtmlExportTransformer.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- extract HTML export transformation logic from CheckerMainForm into EndpointHtmlExportTransformer
- keep existing CheckerMainForm methods as wrappers to preserve call sites and behavior
- add structured export characterization tests for:
  - auto refresh meta tag injection
  - endpoint row hyperlink onclick injection
  - refresh button CSS injection

## Verification
- dotnet run --project tests/StructuredExport.Tests/StructuredExport.Tests.csproj
- dotnet build src/EndpointChecker.csproj --no-restore -p:EnableWindowsTargeting=true -v:minimal
- full-cycle verification executed:
  - restore/clean/build/analyzers on src/EndpointChecker.csproj
  - all standalone test suites
- formatting distinction maintained:
  - dotnet format src/EndpointChecker.sln --verify-no-changes --no-restore => GENERAL_FORMAT_EXIT=2
  - dotnet format whitespace src/EndpointChecker.sln --verify-no-changes --no-restore => WHITESPACE_FORMAT_EXIT=0

## Compatibility
- no XLSX/HTML output contract redesign
- no new dependencies
- no worker model change
- no repository-wide formatting changes