### PR TITLE
refactor: consolidate UI thread helper wrappers

### DIFF
--- a/src/AutoUpdaterDialog.cs
+++ b/src/AutoUpdaterDialog.cs
@@ -220,12 +220,7 @@ namespace EndpointChecker
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Application.DoEvents();
-                Invoke(action);
-            }
-            catch { }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action), Application.DoEvents);
         }
     }
 }

--- a/src/CheckerMainForm.cs
+++ b/src/CheckerMainForm.cs
@@ -5117,25 +5117,12 @@ namespace EndpointChecker
 
         public void NewBackgroundThread(Action action)
         {
-            Application.DoEvents();
-
-            new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
-                action();
-            })
-            .Start();
+            UiThreadHelpers.StartBackgroundThread(action, Application.DoEvents);
         }
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Invoke(action);
-            }
-            catch
-            {
-            }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action));
         }
 
         private int sortColumn = -1;

--- a/src/EndpointDetailsDialog.cs
+++ b/src/EndpointDetailsDialog.cs
@@ -1468,27 +1468,12 @@ namespace EndpointChecker
 
         public void NewBackgroundThread(Action action)
         {
-            Application.DoEvents();
-
-            new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
-                action();
-            })
-            .Start();
+            UiThreadHelpers.StartBackgroundThread(action, Application.DoEvents);
         }
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Application.DoEvents();
-
-                Invoke(action);
-            }
-            catch
-            {
-            }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action), Application.DoEvents);
         }
 
         public void pb_GeoLocation_Map_Click(object sender, EventArgs e)

--- a/src/ExceptionDialog.cs
+++ b/src/ExceptionDialog.cs
@@ -326,27 +326,12 @@ namespace EndpointChecker
 
         public void NewBackgroundThread(Action action)
         {
-            Application.DoEvents();
-
-            new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
-                action();
-            })
-            .Start();
+            UiThreadHelpers.StartBackgroundThread(action, Application.DoEvents);
         }
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Application.DoEvents();
-
-                Invoke(action);
-            }
-            catch
-            {
-            }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action), Application.DoEvents);
         }
 
         public void btn_DontSend_Click(object sender, EventArgs e)

--- a/src/FeatureRequestDialog.cs
+++ b/src/FeatureRequestDialog.cs
@@ -172,27 +172,12 @@ namespace EndpointChecker
 
         public void NewBackgroundThread(Action action)
         {
-            Application.DoEvents();
-
-            new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
-                action();
-            })
-            .Start();
+            UiThreadHelpers.StartBackgroundThread(action, Application.DoEvents);
         }
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Application.DoEvents();
-
-                Invoke(action);
-            }
-            catch
-            {
-            }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action), Application.DoEvents);
         }
 
         public void btn_Send_Click(object sender, EventArgs e)

--- a/src/SpeedTestDialog.cs
+++ b/src/SpeedTestDialog.cs
@@ -1978,27 +1978,12 @@ namespace EndpointChecker
 
         public void NewBackgroundThread(Action action)
         {
-            Application.DoEvents();
-
-            new Thread(() =>
-            {
-                Thread.CurrentThread.IsBackground = true;
-                action();
-            })
-            .Start();
+            UiThreadHelpers.StartBackgroundThread(action, Application.DoEvents);
         }
 
         public void ThreadSafeInvoke(Action action)
         {
-            try
-            {
-                Application.DoEvents();
-
-                Invoke(action);
-            }
-            catch
-            {
-            }
+            UiThreadHelpers.SafeInvoke(() => Invoke(action), Application.DoEvents);
         }
 
         public void SpeedTestDialog_FormClosing(object sender, FormClosingEventArgs e)

--- a/src/UiThreadHelpers.cs
+++ b/src/UiThreadHelpers.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+
+namespace EndpointChecker
+{
+    internal static class UiThreadHelpers
+    {
+        public static void StartBackgroundThread(Action action, Action beforeStart = null)
+        {
+            if (beforeStart != null)
+            {
+                beforeStart();
+            }
+
+            Thread thread = new Thread(() =>
+            {
+                Thread.CurrentThread.IsBackground = true;
+                action();
+            });
+
+            thread.Start();
+        }
+
+        public static void SafeInvoke(Action invokeAction, Action beforeInvoke = null)
+        {
+            try
+            {
+                if (beforeInvoke != null)
+                {
+                    beforeInvoke();
+                }
+
+                invokeAction();
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
@@ -14,5 +14,6 @@
     <Compile Include="..\..\src\EndpointCheckResultFactory.cs" Link="EndpointCheckResultFactory.cs" />
     <Compile Include="..\..\src\EndpointProtocolRouteResolver.cs" Link="EndpointProtocolRouteResolver.cs" />
     <Compile Include="..\..\src\EndpointScanWorkflowRules.cs" Link="EndpointScanWorkflowRules.cs" />
+    <Compile Include="..\..\src\UiThreadHelpers.cs" Link="UiThreadHelpers.cs" />
   </ItemGroup>
 </Project>

--- a/tests/EndpointCheckingCore.Tests/UiThreadHelpersTests.cs
+++ b/tests/EndpointCheckingCore.Tests/UiThreadHelpersTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using EndpointChecker;
+using Xunit;
+
+namespace EndpointCheckingCore.Tests
+{
+    public class UiThreadHelpersTests
+    {
+        [Fact]
+        public void StartBackgroundThread_InvokesBeforeStartAndRunsAction()
+        {
+            bool beforeStartCalled = false;
+            bool actionCalled = false;
+            using (ManualResetEventSlim done = new ManualResetEventSlim(false))
+            {
+                UiThreadHelpers.StartBackgroundThread(
+                    () =>
+                    {
+                        actionCalled = true;
+                        done.Set();
+                    },
+                    () => beforeStartCalled = true);
+
+                Assert.True(done.Wait(TimeSpan.FromSeconds(5)), "Background action did not complete in time.");
+            }
+
+            Assert.True(beforeStartCalled);
+            Assert.True(actionCalled);
+        }
+
+        [Fact]
+        public void StartBackgroundThread_RunsOnBackgroundThread()
+        {
+            bool isBackground = false;
+            using (ManualResetEventSlim done = new ManualResetEventSlim(false))
+            {
+                UiThreadHelpers.StartBackgroundThread(() =>
+                {
+                    isBackground = Thread.CurrentThread.IsBackground;
+                    done.Set();
+                });
+
+                Assert.True(done.Wait(TimeSpan.FromSeconds(5)), "Background action did not complete in time.");
+            }
+
+            Assert.True(isBackground);
+        }
+
+        [Fact]
+        public void SafeInvoke_InvokesBeforeInvokeAndAction()
+        {
+            bool beforeInvokeCalled = false;
+            bool actionCalled = false;
+
+            UiThreadHelpers.SafeInvoke(
+                () => actionCalled = true,
+                () => beforeInvokeCalled = true);
+
+            Assert.True(beforeInvokeCalled);
+            Assert.True(actionCalled);
+        }
+
+        [Fact]
+        public void SafeInvoke_SwallowsExceptionFromInvokeAction()
+        {
+            Exception exception = Record.Exception(() =>
+                UiThreadHelpers.SafeInvoke(() => throw new InvalidOperationException("expected")));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SafeInvoke_SwallowsExceptionFromBeforeInvoke()
+        {
+            bool actionCalled = false;
+
+            Exception exception = Record.Exception(() =>
+                UiThreadHelpers.SafeInvoke(
+                    () => actionCalled = true,
+                    () => throw new InvalidOperationException("expected")));
+
+            Assert.Null(exception);
+            Assert.False(actionCalled);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract duplicated WinForms threading helpers into shared internal UiThreadHelpers
- preserve per-form wrapper behavior (including Application.DoEvents differences)
- add characterization tests for helper sequencing, background-thread flag, and exception swallowing

## Validation
- dotnet restore src/EndpointChecker.sln
- dotnet build src/EndpointChecker.sln -c Release
- dotnet test tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj -c Release --no-build
- dotnet test tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj -c Release --no-build
- dotnet test tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj -c Release --no-build
- dotnet test tests/ExportOptions.Tests/ExportOptions.Tests.csproj -c Release --no-build
- dotnet test tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj -c Release --no-build
- dotnet test tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj -c Release --no-build
- dotnet test tests/StructuredExport.Tests/StructuredExport.Tests.csproj -c Release --no-build
- dotnet format whitespace src/EndpointChecker.sln --verify-no-changes (exit 0)
- dotnet format src/EndpointChecker.sln --verify-no-changes (exit 2, existing general format drift baseline)