### PR TITLE
refactor: extract report mail table builder

### DIFF
--- a/src/ExceptionDialog.cs
+++ b/src/ExceptionDialog.cs
@@ -12,7 +12,6 @@ using System.Net.Mail;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using static EndpointChecker.Program;
@@ -109,22 +108,11 @@ namespace EndpointChecker
 
             // E-MAIL SUBJECT AND CREATE BODY HTML TABLE
             string eMailMessageSubject = app_ApplicationName + " Unhandled Exception Report";
-            string eMailMessageBody = string.Empty;
-
-            StringBuilder mailMessageString = new StringBuilder();
-            mailMessageString.Append("<table border=\"3\" bordercolor=\"#FF0000\" bgcolor=\"#FFC0CB\" cellpadding=\"5\" cellspacing=\"10\">");
-
-            foreach (Property reportItem in reportItems)
-            {
-                mailMessageString.Append("<tr>");
-                mailMessageString.AppendFormat("<td>{0}</td><td>{1}</td>",
-                    WebUtility.HtmlEncode(reportItem.ItemName),
-                    WebUtility.HtmlEncode(reportItem.ItemValue));
-                mailMessageString.Append("</tr>");
-            }
-
-            mailMessageString.Append("</table>");
-            eMailMessageBody = mailMessageString.ToString();
+            string eMailMessageBody = ReportMailTableBuilder.Build(
+                reportItems.Select(reportItem =>
+                    new KeyValuePair<string, string>(reportItem.ItemName, reportItem.ItemValue ?? string.Empty)),
+                "#FF0000",
+                "#FFC0CB");
 
             try
             {

--- a/src/FeatureRequestDialog.cs
+++ b/src/FeatureRequestDialog.cs
@@ -6,9 +6,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net.Mail;
-using System.Text;
 using System.Threading;
-using System.Net;
 using System.Windows.Forms;
 using static EndpointChecker.Program;
 
@@ -44,22 +42,11 @@ namespace EndpointChecker
 
             // E-MAIL SUBJECT AND CREATE BODY HTML TABLE
             string eMailMessageSubject = app_ApplicationName + " Feature Request";
-            string eMailMessageBody = string.Empty;
-
-            StringBuilder mailMessageString = new StringBuilder();
-            mailMessageString.Append("<table border=\"3\" bordercolor=\"#003CFF\" bgcolor=\"#91ABFF\" cellpadding=\"5\" cellspacing=\"10\">");
-
-            foreach (Property reportItem in reportItems)
-            {
-                mailMessageString.Append("<tr>");
-                mailMessageString.AppendFormat("<td>{0}</td><td>{1}</td>",
-                    WebUtility.HtmlEncode(reportItem.ItemName),
-                    WebUtility.HtmlEncode(reportItem.ItemValue));
-                mailMessageString.Append("</tr>");
-            }
-
-            mailMessageString.Append("</table>");
-            eMailMessageBody = mailMessageString.ToString();
+            string eMailMessageBody = ReportMailTableBuilder.Build(
+                reportItems.Select(reportItem =>
+                    new KeyValuePair<string, string>(reportItem.ItemName, reportItem.ItemValue ?? string.Empty)),
+                "#003CFF",
+                "#91ABFF");
 
             try
             {

--- a/src/ReportMailTableBuilder.cs
+++ b/src/ReportMailTableBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace EndpointChecker
+{
+    internal static class ReportMailTableBuilder
+    {
+        public static string Build(
+            IEnumerable<KeyValuePair<string, string>> rows,
+            string borderColor,
+            string backgroundColor)
+        {
+            if (rows == null)
+            {
+                throw new ArgumentNullException(nameof(rows));
+            }
+
+            StringBuilder mailMessageString = new StringBuilder();
+            mailMessageString.AppendFormat(
+                "<table border=\"3\" bordercolor=\"{0}\" bgcolor=\"{1}\" cellpadding=\"5\" cellspacing=\"10\">",
+                borderColor,
+                backgroundColor);
+
+            foreach (KeyValuePair<string, string> row in rows)
+            {
+                mailMessageString.Append("<tr>");
+                mailMessageString.AppendFormat(
+                    "<td>{0}</td><td>{1}</td>",
+                    WebUtility.HtmlEncode(row.Key),
+                    WebUtility.HtmlEncode(row.Value));
+                mailMessageString.Append("</tr>");
+            }
+
+            mailMessageString.Append("</table>");
+            return mailMessageString.ToString();
+        }
+    }
+}

--- a/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
+++ b/tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\..\src\EndpointCheckResultFactory.cs" Link="EndpointCheckResultFactory.cs" />
     <Compile Include="..\..\src\EndpointProtocolRouteResolver.cs" Link="EndpointProtocolRouteResolver.cs" />
     <Compile Include="..\..\src\EndpointScanWorkflowRules.cs" Link="EndpointScanWorkflowRules.cs" />
+    <Compile Include="..\..\src\ReportMailTableBuilder.cs" Link="ReportMailTableBuilder.cs" />
     <Compile Include="..\..\src\UiThreadHelpers.cs" Link="UiThreadHelpers.cs" />
   </ItemGroup>
 </Project>

--- a/tests/EndpointCheckingCore.Tests/ReportMailTableBuilderTests.cs
+++ b/tests/EndpointCheckingCore.Tests/ReportMailTableBuilderTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using EndpointChecker;
+using Xunit;
+
+namespace EndpointCheckingCore.Tests
+{
+    public class ReportMailTableBuilderTests
+    {
+        [Fact]
+        public void Build_UsesExpectedTableWrapper()
+        {
+            string html = ReportMailTableBuilder.Build(
+                new[]
+                {
+                    new KeyValuePair<string, string>("Name", "Value")
+                },
+                "#ABCDEF",
+                "#123456");
+
+            Assert.StartsWith("<table border=\"3\" bordercolor=\"#ABCDEF\" bgcolor=\"#123456\" cellpadding=\"5\" cellspacing=\"10\">", html);
+            Assert.EndsWith("</table>", html);
+        }
+
+        [Fact]
+        public void Build_HtmlEncodesKeyAndValue()
+        {
+            string html = ReportMailTableBuilder.Build(
+                new[]
+                {
+                    new KeyValuePair<string, string>("A < B", "X & Y > Z")
+                },
+                "#000000",
+                "#FFFFFF");
+
+            Assert.Contains("<td>A &lt; B</td><td>X &amp; Y &gt; Z</td>", html);
+        }
+
+        [Fact]
+        public void Build_ProducesRowPerInputItem()
+        {
+            string html = ReportMailTableBuilder.Build(
+                new[]
+                {
+                    new KeyValuePair<string, string>("One", "1"),
+                    new KeyValuePair<string, string>("Two", "2"),
+                    new KeyValuePair<string, string>("Three", "3")
+                },
+                "#000000",
+                "#FFFFFF");
+
+            int rows = html.Split(new[] { "<tr>" }, System.StringSplitOptions.None).Length - 1;
+            Assert.Equal(3, rows);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract HTML report-table generation into shared internal ReportMailTableBuilder
- keep both ExceptionDialog and FeatureRequestDialog subjects/rows/colors/sending flow unchanged
- add characterization tests for wrapper shape, row count, and HTML encoding

## Validation
- dotnet restore src/EndpointChecker.sln
- dotnet build src/EndpointChecker.sln -c Release
- dotnet test tests/EndpointCheckingCore.Tests/EndpointCheckingCore.Tests.csproj -c Release --no-build
- dotnet test tests/EndpointDefinitionParser.Tests/EndpointDefinitionParser.Tests.csproj -c Release --no-build
- dotnet test tests/ExportFileSet.Tests/ExportFileSet.Tests.csproj -c Release --no-build
- dotnet test tests/ExportOptions.Tests/ExportOptions.Tests.csproj -c Release --no-build
- dotnet test tests/ExportRunSummary.Tests/ExportRunSummary.Tests.csproj -c Release --no-build
- dotnet test tests/HttpCompatibility.Tests/HttpCompatibility.Tests.csproj -c Release --no-build
- dotnet test tests/StructuredExport.Tests/StructuredExport.Tests.csproj -c Release --no-build
- dotnet format whitespace src/EndpointChecker.sln --verify-no-changes (exit 0)
- dotnet format src/EndpointChecker.sln --verify-no-changes (exit 2, existing general format drift baseline)